### PR TITLE
feat: migrate Firestore schema from UID-based to username-based subco…

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -1,15 +1,11 @@
 {
   "indexes": [
     {
-      "collectionGroup": "chatThreads",
+      "collectionGroup": "workouts",
       "queryScope": "COLLECTION",
       "fields": [
         {
-          "fieldPath": "userId",
-          "order": "ASCENDING"
-        },
-        {
-          "fieldPath": "updatedAt",
+          "fieldPath": "date",
           "order": "DESCENDING"
         }
       ]
@@ -19,12 +15,64 @@
       "queryScope": "COLLECTION",
       "fields": [
         {
-          "fieldPath": "assignedTo",
+          "fieldPath": "source",
           "order": "ASCENDING"
         },
         {
-          "fieldPath": "type",
+          "fieldPath": "date",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "workouts",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "completed",
           "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "date",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "comments",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "createdAt",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "users",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "coachUsername",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "role",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "personalRecords",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "userId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "date",
+          "order": "DESCENDING"
         }
       ]
     }

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,44 +1,51 @@
 rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
-    
-    // Users collection - users can only read/write their own data
-    match /users/{userId} {
-      allow read: if request.auth != null;
-      allow write: if request.auth != null && request.auth.uid == userId;
+
+    // UID → username mapping (created during registration)
+    match /userMappings/{uid} {
+      allow read: if request.auth != null && request.auth.uid == uid;
+      allow create: if request.auth != null && request.auth.uid == uid;
+      allow update, delete: if false; // Immutable
     }
-    
-    // Workouts collection
-    match /workouts/{workoutId} {
+
+    // Users keyed by username
+    match /users/{username} {
       allow read: if request.auth != null;
-      allow create: if request.auth != null && request.auth.uid == request.resource.data.createdBy;
-      allow update: if request.auth != null && (
-        request.auth.uid == resource.data.createdBy ||
-        request.auth.uid == resource.data.assignedTo
-      );
-      allow delete: if request.auth != null && request.auth.uid == resource.data.createdBy;
-      
-      // Workout comments subcollection
-      match /comments/{commentId} {
+      allow create: if request.auth != null && request.resource.data.uid == request.auth.uid;
+      allow update: if request.auth != null && resource.data.uid == request.auth.uid;
+      allow delete: if false;
+
+      // Workouts subcollection under each user
+      match /workouts/{workoutId} {
         allow read: if request.auth != null;
+        // Athletes can create their own; coaches can create for athletes (app-level auth)
         allow create: if request.auth != null;
-        allow delete: if request.auth != null && request.auth.uid == resource.data.userId;
+        allow update: if request.auth != null;
+        allow delete: if request.auth != null;
+
+        // Comments on workouts
+        match /comments/{commentId} {
+          allow read: if request.auth != null;
+          allow create: if request.auth != null;
+          allow delete: if request.auth != null;
+        }
       }
     }
-    
-    // Personal Records collection
+
+    // Personal Records (flat collection, userId field for ownership)
     match /personalRecords/{recordId} {
-      allow read: if request.auth != null && request.auth.uid == resource.data.userId;
-      allow create: if request.auth != null && request.auth.uid == request.resource.data.userId;
-      allow update, delete: if request.auth != null && request.auth.uid == resource.data.userId;
+      allow read: if request.auth != null;
+      allow create: if request.auth != null;
+      allow update, delete: if request.auth != null;
     }
-    
-    // Chat Threads collection - NEW!
+
+    // AI Chat Threads (userId field = auth UID)
     match /chatThreads/{threadId} {
-      allow read: if request.auth != null && request.auth.uid == resource.data.userId;
-      allow create: if request.auth != null && request.auth.uid == request.resource.data.userId;
-      allow update: if request.auth != null && request.auth.uid == resource.data.userId;
-      allow delete: if request.auth != null && request.auth.uid == resource.data.userId;
+      allow read: if request.auth != null && resource.data.userId == request.auth.uid;
+      allow create: if request.auth != null && request.resource.data.userId == request.auth.uid;
+      allow update: if request.auth != null && resource.data.userId == request.auth.uid;
+      allow delete: if request.auth != null && resource.data.userId == request.auth.uid;
     }
   }
 }

--- a/src/app/(auth)/choose-username/page.tsx
+++ b/src/app/(auth)/choose-username/page.tsx
@@ -1,0 +1,156 @@
+'use client';
+
+import { useState, useCallback, useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { createGoogleUser } from '@/lib/firebase/auth';
+import { validateUsername, isUsernameAvailable } from '@/lib/firebase/userMapping';
+import { useAuthStore } from '@/lib/stores/authStore';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { toast } from 'sonner';
+import { Dumbbell, Loader2, AtSign, ArrowRight, AlertCircle } from 'lucide-react';
+
+export default function ChooseUsernamePage() {
+  const [username, setUsername] = useState('');
+  const [usernameError, setUsernameError] = useState('');
+  const [checking, setChecking] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const router = useRouter();
+
+  const pendingGoogleUser = useAuthStore((s) => s.pendingGoogleUser);
+  const needsUsername = useAuthStore((s) => s.needsUsername);
+  const setUser = useAuthStore((s) => s.setUser);
+  const setNeedsUsername = useAuthStore((s) => s.setNeedsUsername);
+
+  useEffect(() => {
+    if (!needsUsername || !pendingGoogleUser) {
+      router.replace('/login');
+    }
+  }, [needsUsername, pendingGoogleUser, router]);
+
+  const handleUsernameChange = useCallback(async (value: string) => {
+    const lower = value.toLowerCase().replace(/[^a-z0-9_]/g, '');
+    setUsername(lower);
+    setUsernameError('');
+
+    if (!lower) return;
+
+    const validation = validateUsername(lower);
+    if (!validation.valid) {
+      setUsernameError(validation.error || '');
+      return;
+    }
+
+    setChecking(true);
+    const available = await isUsernameAvailable(lower);
+    setChecking(false);
+    if (!available) {
+      setUsernameError('Username is already taken');
+    }
+  }, []);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!pendingGoogleUser) return;
+
+    setUsernameError('');
+    setLoading(true);
+
+    const validation = validateUsername(username);
+    if (!validation.valid) {
+      setUsernameError(validation.error || '');
+      setLoading(false);
+      return;
+    }
+
+    const available = await isUsernameAvailable(username);
+    if (!available) {
+      setUsernameError('Username is already taken');
+      setLoading(false);
+      return;
+    }
+
+    try {
+      const user = await createGoogleUser(
+        pendingGoogleUser.uid,
+        pendingGoogleUser.email,
+        pendingGoogleUser.displayName,
+        username,
+        pendingGoogleUser.photoURL,
+      );
+
+      setUser(user);
+      setNeedsUsername(false);
+      toast.success('Account created!');
+      router.push('/onboarding');
+    } catch (error: any) {
+      toast.error(error.message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (!pendingGoogleUser) return null;
+
+  return (
+    <div className="min-h-screen flex items-center justify-center p-4 bg-black relative overflow-hidden">
+      <div className="absolute inset-0 overflow-hidden pointer-events-none">
+        <div className="absolute -top-40 -left-40 w-[500px] h-[500px] bg-red-600/10 rounded-full blur-[120px]" />
+        <div className="absolute bottom-0 right-0 w-[400px] h-[400px] bg-red-900/10 rounded-full blur-[100px]" />
+      </div>
+
+      <div className="w-full max-w-md relative z-10">
+        <div className="text-center mb-8">
+          <div className="inline-flex items-center justify-center w-16 h-16 rounded-2xl bg-black shadow-xl shadow-black/25 mb-4">
+            <Dumbbell className="w-8 h-8 text-white" />
+          </div>
+          <h1 className="text-2xl font-black text-white uppercase tracking-tight">Choose Your Username</h1>
+          <p className="text-white/40 mt-1">Welcome, {pendingGoogleUser.displayName}! Pick a unique username.</p>
+        </div>
+
+        <div className="bg-white/[0.03] backdrop-blur-xl border border-white/10 rounded-2xl p-8 shadow-2xl">
+          <form onSubmit={handleSubmit} className="space-y-5">
+            <div className="space-y-2">
+              <Label htmlFor="username" className="text-sm font-medium text-white/70">Username</Label>
+              <div className="relative">
+                <AtSign className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-white/30" />
+                <Input
+                  id="username"
+                  type="text"
+                  placeholder="johndoe"
+                  value={username}
+                  onChange={(e) => handleUsernameChange(e.target.value)}
+                  required
+                  maxLength={20}
+                  autoFocus
+                  className={`pl-10 h-11 bg-white/5 border-white/10 text-white placeholder:text-white/25 focus:border-red-500 focus:ring-red-500/20 transition-colors ${usernameError ? 'border-red-500' : ''}`}
+                />
+                {checking && <Loader2 className="absolute right-3 top-1/2 -translate-y-1/2 w-4 h-4 text-white/30 animate-spin" />}
+              </div>
+              {usernameError && (
+                <div className="flex items-center gap-1.5 text-red-400 text-sm animate-in fade-in slide-in-from-top-1 duration-200">
+                  <AlertCircle className="w-3.5 h-3.5 shrink-0" />
+                  <span>{usernameError}</span>
+                </div>
+              )}
+              <p className="text-xs text-white/25">Lowercase letters, numbers, underscores. 3-20 characters.</p>
+            </div>
+
+            <Button
+              type="submit"
+              className="w-full h-11 font-bold bg-red-600 hover:bg-red-700 text-white shadow-lg shadow-red-600/25 border-0 transition-all"
+              disabled={loading || checking || !!usernameError || !username}
+            >
+              {loading ? (
+                <><Loader2 className="w-4 h-4 mr-2 animate-spin" />Creating account...</>
+              ) : (
+                <>Continue<ArrowRight className="w-4 h-4 ml-2" /></>
+              )}
+            </Button>
+          </form>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(dashboard)/calendar/page.tsx
+++ b/src/app/(dashboard)/calendar/page.tsx
@@ -116,12 +116,12 @@ export default function CalendarPage() {
 
   useEffect(() => {
     if (!user) return;
-    getUserWorkouts(user.uid, user.role).then(data => {
+    getUserWorkouts(user.username, user.role).then(data => {
       setWorkouts(data);
       setLoading(false);
     });
     if (isCoach) {
-      getCoachStudents(user.uid).then(data => {
+      getCoachStudents(user.username).then(data => {
         setAthletes(data.map((a: any) => ({ uid: a.uid, displayName: a.displayName || a.email || 'Unknown' })));
       });
     }
@@ -176,8 +176,8 @@ export default function CalendarPage() {
     e.preventDefault();
     e.stopPropagation();
     try {
-      await completeWorkout(workout.id, !workout.completed);
-      const data = await getUserWorkouts(user!.uid, user!.role);
+      await completeWorkout(workout.ownerUsername, workout.id, !workout.completed);
+      const data = await getUserWorkouts(user!.username, user!.role);
       setWorkouts(data);
       toast.success(workout.completed ? 'Marked incomplete' : 'Marked complete!');
     } catch (err: any) {

--- a/src/app/(dashboard)/dashboard/page.tsx
+++ b/src/app/(dashboard)/dashboard/page.tsx
@@ -77,7 +77,7 @@ export default function DashboardPage() {
   // Refresh workouts from Firestore (used by auto-sync callback)
   const refreshWorkouts = useCallback(async () => {
     if (!user) return;
-    const workoutData = await getUserWorkouts(user.uid, user.role);
+    const workoutData = await getUserWorkouts(user.username, user.role);
     setWorkouts(workoutData);
   }, [user]);
 
@@ -87,7 +87,7 @@ export default function DashboardPage() {
   useEffect(() => {
     async function loadData() {
       if (!user) return;
-      const workoutData = await getUserWorkouts(user.uid, user.role);
+      const workoutData = await getUserWorkouts(user.username, user.role);
       setWorkouts(workoutData);
       setLoading(false);
       setTimeout(() => setReady(true), 100);

--- a/src/app/(dashboard)/onboarding/page.tsx
+++ b/src/app/(dashboard)/onboarding/page.tsx
@@ -93,7 +93,7 @@ export default function OnboardingPage() {
         updatedAt: serverTimestamp(),
       };
 
-      await updateDoc(doc(getDbInstance(), 'users', user.uid), updateData);
+      await updateDoc(doc(getDbInstance(), 'users', user.username), updateData);
 
       completingRef.current = true;
       setUser({
@@ -106,7 +106,7 @@ export default function OnboardingPage() {
       if (connectStrava) {
         // Redirect to Strava OAuth — it will come back to /settings?strava=connected
         // then user lands on dashboard
-        window.location.href = `/api/auth/strava/authorize?userId=${user.uid}`;
+        window.location.href = `/api/auth/strava/authorize?userId=${user.username}`;
         return;
       }
 

--- a/src/app/(dashboard)/profile/page.tsx
+++ b/src/app/(dashboard)/profile/page.tsx
@@ -161,7 +161,7 @@ export default function ProfilePage() {
     setSaving(true);
     try {
       const profileCompleted = calculateCompletionFromForm(data, user);
-      await updateDoc(doc(getDbInstance(), 'users', user.uid), {
+      await updateDoc(doc(getDbInstance(), 'users', user.username), {
         displayName: data.displayName,
         bio: data.bio || null,
         timezone: data.timezone || null,

--- a/src/app/(dashboard)/reports/page.tsx
+++ b/src/app/(dashboard)/reports/page.tsx
@@ -63,7 +63,7 @@ export default function ReportsPage() {
     setLoadingWorkouts(true);
     try {
       const role = user.role === 'student' ? 'athlete' : user.role;
-      const data = await getUserWorkouts(user.uid, role as 'coach' | 'athlete');
+      const data = await getUserWorkouts(user.username, role as 'coach' | 'athlete');
       setWorkouts(data);
     } catch (err) {
       console.error('Failed to fetch workouts:', err);

--- a/src/app/(dashboard)/settings/page.tsx
+++ b/src/app/(dashboard)/settings/page.tsx
@@ -44,13 +44,13 @@ function SettingsContent() {
     }
   }, [searchParams, router]);
 
-  const handleConnectStrava = () => { setIsConnectingStrava(true); window.location.href = `/api/auth/strava/authorize?userId=${user?.uid}`; };
+  const handleConnectStrava = () => { setIsConnectingStrava(true); window.location.href = `/api/auth/strava/authorize?userId=${user?.username}`; };
 
   const handleDisconnectStrava = async () => {
     if (!user) return;
     setIsDisconnectingStrava(true);
     try {
-      const response = await fetch('/api/auth/strava/disconnect', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ userId: user.uid }) });
+      const response = await fetch('/api/auth/strava/disconnect', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ userId: user.username }) });
       if (!response.ok) throw new Error('Failed to disconnect');
       setUser({ ...user, stravaId: undefined, stravaAccessToken: undefined, stravaRefreshToken: undefined, stravaConnectedAt: undefined });
       toast.success('Strava disconnected');
@@ -65,7 +65,7 @@ function SettingsContent() {
       // First, check for duplicates (unless we already have decisions)
       if (!decisions) {
         const checkResponse = await fetch(
-          `/api/strava/sync?userId=${user.uid}&checkDuplicates=true`,
+          `/api/strava/sync?userId=${user.username}&checkDuplicates=true`,
           { headers: { 'Accept': 'application/json' } }
         );
 
@@ -102,7 +102,7 @@ function SettingsContent() {
       // Perform the actual sync with decisions
       const decisionsParam = decisions ? `&decisions=${encodeURIComponent(JSON.stringify(decisions))}` : '';
       const response = await fetch(
-        `/api/strava/sync?userId=${user.uid}${decisionsParam}`,
+        `/api/strava/sync?userId=${user.username}${decisionsParam}`,
         { headers: { 'Accept': 'application/json' } }
       );
 

--- a/src/app/(dashboard)/workouts/[id]/edit/page.tsx
+++ b/src/app/(dashboard)/workouts/[id]/edit/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { useRouter, useParams } from 'next/navigation';
+import { useRouter, useParams, useSearchParams } from 'next/navigation';
 import { useAuthStore } from '@/lib/stores/authStore';
 import { getWorkout, updateWorkout, getCoachStudents } from '@/lib/firebase/firestore';
 import { WorkoutForm } from '@/components/workouts/WorkoutForm';
@@ -77,6 +77,7 @@ function ensureTypeData(workout: any): Record<string, any> {
 export default function EditWorkoutPage() {
   const router = useRouter();
   const params = useParams();
+  const searchParams = useSearchParams();
   const user = useAuthStore((state) => state.user);
   const loading = useAuthStore((state) => state.loading);
   const [workout, setWorkout] = useState<Workout | null>(null);
@@ -102,25 +103,26 @@ export default function EditWorkoutPage() {
       setDataLoading(true);
       
       // Load workout
-      const workoutData = await getWorkout(params.id);
-      
+      const ownerUsername = searchParams.get('owner') || user!.username;
+      const workoutData = await getWorkout(ownerUsername, params.id);
+
       if (!workoutData) {
         toast.error('Workout not found');
         router.push('/workouts');
         return;
       }
-      
+
       // Verify ownership
       if (workoutData.createdBy !== user.uid) {
         toast.error('You can only edit your own workouts');
         router.push('/workouts');
         return;
       }
-      
+
       setWorkout(workoutData);
-      
+
       // Load students
-      const studentsList = await getCoachStudents(user.uid);
+      const studentsList = await getCoachStudents(user.username);
       setStudents(studentsList);
       
       setDataLoading(false);
@@ -129,14 +131,15 @@ export default function EditWorkoutPage() {
     if (user?.role === 'coach') {
       loadData();
     }
-  }, [user, loading, router, params.id]);
+  }, [user, loading, router, params.id, searchParams]);
 
   const handleSubmit = async (data: WorkoutSchema) => {
     if (!params.id || typeof params.id !== 'string') return;
 
     setSubmitting(true);
     try {
-      await updateWorkout(params.id, data);
+      const ownerUsername = workout?.ownerUsername || searchParams.get('owner') || user!.username;
+      await updateWorkout(ownerUsername, params.id, data);
       toast.success('Workout updated successfully');
       router.push(`/workouts/${params.id}`);
     } catch (error: any) {

--- a/src/app/(dashboard)/workouts/[id]/page.tsx
+++ b/src/app/(dashboard)/workouts/[id]/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { useRouter, useParams } from 'next/navigation';
+import { useRouter, useParams, useSearchParams } from 'next/navigation';
 import { useAuthStore } from '@/lib/stores/authStore';
 import { getWorkout, completeWorkout } from '@/lib/firebase/firestore';
 import { Workout } from '@/types';
@@ -52,6 +52,7 @@ import {
 export default function WorkoutDetailPage() {
   const router = useRouter();
   const params = useParams();
+  const searchParams = useSearchParams();
   const user = useAuthStore((state) => state.user);
   const loading = useAuthStore((state) => state.loading);
   const [workout, setWorkout] = useState<Workout | null>(null);
@@ -75,7 +76,8 @@ export default function WorkoutDetailPage() {
       if (!params.id || typeof params.id !== 'string') return;
 
       setDataLoading(true);
-      const data = await getWorkout(params.id);
+      const ownerUsername = searchParams.get('owner') || user!.username;
+      const data = await getWorkout(ownerUsername, params.id);
 
       if (!data) {
         toast.error('Workout not found');
@@ -90,14 +92,14 @@ export default function WorkoutDetailPage() {
     if (user) {
       loadWorkout();
     }
-  }, [user, loading, router, params.id]);
+  }, [user, loading, router, params.id, searchParams]);
 
   const handleComplete = async (notes?: string) => {
     if (!workout) return;
 
     setIsUpdating(true);
     try {
-      await completeWorkout(workout.id, true, notes);
+      await completeWorkout(workout.ownerUsername, workout.id, true, notes);
       setWorkout({
         ...workout,
         completed: true,
@@ -118,7 +120,7 @@ export default function WorkoutDetailPage() {
 
     setIsUpdating(true);
     try {
-      await completeWorkout(workout.id, false);
+      await completeWorkout(workout.ownerUsername, workout.id, false);
       setWorkout({
         ...workout,
         completed: false,
@@ -476,6 +478,7 @@ export default function WorkoutDetailPage() {
       <CommentSection
         workoutId={workout.id}
         workoutName={workout.name}
+        ownerUsername={workout.ownerUsername}
         currentUserId={user.uid}
         currentUserName={user.displayName}
         currentUserRole={user.role}

--- a/src/app/(dashboard)/workouts/new/page.tsx
+++ b/src/app/(dashboard)/workouts/new/page.tsx
@@ -34,13 +34,13 @@ export default function NewWorkoutPage() {
   const aiGenerated = searchParams.get('aiGenerated') === 'true';
 
   const isCoach = user?.role === 'coach';
-  const isUnconnectedAthlete = (user?.role === 'athlete' || user?.role === 'student') && !user?.coachId;
+  const isUnconnectedAthlete = (user?.role === 'athlete' || user?.role === 'student') && !user?.coachUsername;
 
   useEffect(() => {
     async function loadStudents() {
       if (!user || user.role !== 'coach') return;
 
-      const data = await getCoachStudents(user.uid);
+      const data = await getCoachStudents(user.username);
       setStudents(data);
     }
 
@@ -91,7 +91,7 @@ export default function NewWorkoutPage() {
   // Redirect if not authorized (must be coach OR unconnected athlete)
   useEffect(() => {
     if (authLoading) return;
-    const canCreate = user?.role === 'coach' || ((user?.role === 'athlete' || user?.role === 'student') && !user?.coachId);
+    const canCreate = user?.role === 'coach' || ((user?.role === 'athlete' || user?.role === 'student') && !user?.coachUsername);
     if (user && !canCreate) {
       router.push('/dashboard');
     }
@@ -122,7 +122,7 @@ export default function NewWorkoutPage() {
         }
       }
 
-      const newWorkoutId = await createWorkout(workoutData as any, user.uid);
+      const newWorkoutId = await createWorkout(workoutData as any, user.username);
       setShowPreview(false);
 
       toast.success('Workout created successfully!');
@@ -160,6 +160,7 @@ export default function NewWorkoutPage() {
           studentName: athlete.displayName,
           workout: createdWorkoutData,
           workoutId: createdWorkoutId,
+          ownerUsername: athlete.uid,
         }),
       });
       if (!res.ok) {

--- a/src/app/(dashboard)/workouts/page.tsx
+++ b/src/app/(dashboard)/workouts/page.tsx
@@ -35,7 +35,7 @@ function WorkoutsContent() {
 
   const loadWorkouts = useCallback(async () => {
     if (!user) return;
-    const data = await getUserWorkouts(user.uid, user.role);
+    const data = await getUserWorkouts(user.username, user.role);
     // Filter out future workouts — those only show in calendar
     const now = new Date();
     now.setHours(23, 59, 59, 999);
@@ -62,7 +62,8 @@ function WorkoutsContent() {
   const handleDelete = async (id: string) => {
     if (!confirm('Are you sure you want to delete this workout?')) return;
     try {
-      await deleteWorkout(id);
+      const workout = workouts.find(w => w.id === id);
+      await deleteWorkout(workout?.ownerUsername || user!.username, id);
       toast.success('Workout deleted');
       await loadWorkouts();
     } catch (error: any) {
@@ -72,7 +73,8 @@ function WorkoutsContent() {
 
   const handleToggleComplete = async (id: string, completed: boolean, notes?: string) => {
     try {
-      await completeWorkout(id, completed, notes);
+      const workout = workouts.find(w => w.id === id);
+      await completeWorkout(workout?.ownerUsername || user!.username, id, completed, notes);
       toast.success(completed ? 'Workout completed!' : 'Marked incomplete');
       await loadWorkouts();
     } catch (error: any) {
@@ -82,7 +84,7 @@ function WorkoutsContent() {
 
   const handleViewDetails = (id: string) => router.push(`/workouts/${id}`);
 
-  const canManageWorkouts = user?.role === 'coach' || ((user?.role === 'athlete' || user?.role === 'student') && !user?.coachId);
+  const canManageWorkouts = user?.role === 'coach' || ((user?.role === 'athlete' || user?.role === 'student') && !user?.coachUsername);
 
   if (loading || !ready) {
     return (
@@ -196,7 +198,7 @@ function WorkoutsContent() {
       </div>
 
       {/* AI Workout Suggestions - coaches and self-training athletes (no coach) */}
-      {user && (user.role === 'coach' || !user.coachId) && (
+      {user && (user.role === 'coach' || !user.coachUsername) && (
         <AIWorkoutSuggestions
           userId={user.uid}
           recentWorkouts={workouts}

--- a/src/app/api/admin/assign-athletes/route.ts
+++ b/src/app/api/admin/assign-athletes/route.ts
@@ -39,20 +39,20 @@ export async function GET() {
     }
 
     const coachDoc = coachSnap.docs[0];
-    const coachId = coachDoc.id;
+    const coachUsername = coachDoc.id; // doc.id is now username
     const coachData = coachDoc.data();
 
     results.push({
       step: 'coach_found',
       email: COACH_EMAIL,
-      uid: coachId,
+      username: coachUsername,
       name: coachData.displayName,
       role: coachData.role,
     });
 
     // Ensure coach has role = 'coach'
     if (coachData.role !== 'coach') {
-      await adminDb.collection('users').doc(coachId).update({
+      await adminDb.collection('users').doc(coachUsername).update({
         role: 'coach',
         updatedAt: admin.firestore.FieldValue.serverTimestamp(),
       });
@@ -73,12 +73,12 @@ export async function GET() {
       }
 
       const athleteDoc = athleteSnap.docs[0];
-      const athleteId = athleteDoc.id;
+      const athleteUsername = athleteDoc.id; // doc.id is now username
       const athleteData = athleteDoc.data();
 
-      // Update athlete: set coachId and ensure role is athlete
-      await adminDb.collection('users').doc(athleteId).update({
-        coachId: coachId,
+      // Update athlete: set coachUsername and ensure role is athlete
+      await adminDb.collection('users').doc(athleteUsername).update({
+        coachUsername: coachUsername,
         role: athleteData.role === 'student' ? 'athlete' : (athleteData.role || 'athlete'),
         updatedAt: admin.firestore.FieldValue.serverTimestamp(),
       });
@@ -86,16 +86,16 @@ export async function GET() {
       results.push({
         step: 'athlete_assigned',
         email: athleteEmail,
-        uid: athleteId,
+        username: athleteUsername,
         name: athleteData.displayName,
-        coachId: coachId,
-        previousCoachId: athleteData.coachId || 'none',
+        coachUsername: coachUsername,
+        previousCoachUsername: athleteData.coachUsername || 'none',
       });
     }
 
     return NextResponse.json({
       success: true,
-      coach: { email: COACH_EMAIL, uid: coachId },
+      coach: { email: COACH_EMAIL, username: coachUsername },
       results,
       message: `Assigned ${ATHLETE_EMAILS.length} athletes to ${COACH_EMAIL}. You can delete this route now.`,
     });

--- a/src/app/api/ai/backfill-comments/route.ts
+++ b/src/app/api/ai/backfill-comments/route.ts
@@ -13,8 +13,8 @@ export async function POST(request: NextRequest) {
 
     const groq = new Groq({ apiKey: process.env.GROQ_API_KEY.trim() });
 
-    // Find all workouts with route data but no AI comment
-    const snapshot = await adminDb.collection('workouts')
+    // Find all workouts with route data but no AI comment (collectionGroup for subcollections)
+    const snapshot = await adminDb.collectionGroup('workouts')
       .where('routeData.polyline', '!=', null)
       .get();
 
@@ -71,7 +71,9 @@ Return ONLY a JSON object: {"comment": "your fun comment here"}`;
         const comment = parsed.comment?.slice(0, 100);
 
         if (comment) {
-          await adminDb.collection('workouts').doc(doc.id).update({
+          // Use ownerUsername from workout data to construct subcollection path
+          const ownerUsername = workout.ownerUsername || workout.assignedTo;
+          await adminDb.collection('users').doc(ownerUsername).collection('workouts').doc(doc.id).update({
             'routeData.aiComment': comment,
           });
           success++;

--- a/src/app/api/ai/format-workouts/route.ts
+++ b/src/app/api/ai/format-workouts/route.ts
@@ -13,6 +13,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getAdminDb } from '@/lib/firebase/admin';
 import { formatWorkouts, formatWorkoutFallback, WorkoutForFormat } from '@/lib/groq-format';
 import * as admin from 'firebase-admin';
+import { adminResolveUsername } from '@/lib/firebase/adminUserMapping';
 
 export async function POST(request: NextRequest) {
   try {
@@ -24,32 +25,26 @@ export async function POST(request: NextRequest) {
 
     const db = getAdminDb();
 
-    // Fetch workouts
+    // Resolve UID to username
+    const username = await adminResolveUsername(userId);
+
+    // Fetch workouts from user's subcollection
     let snapshot;
     if (workoutIds?.length) {
-      // Fetch specific workouts (batched for Firestore 'in' limit)
+      // Fetch specific workouts from user's subcollection (batched for Firestore 'in' limit)
       const docs: admin.firestore.DocumentSnapshot[] = [];
       for (let i = 0; i < workoutIds.length; i += 10) {
         const batch = workoutIds.slice(i, i + 10);
-        const batchSnap = await db.collection('workouts')
+        const batchSnap = await db.collection('users').doc(username).collection('workouts')
           .where(admin.firestore.FieldPath.documentId(), 'in', batch)
           .get();
         docs.push(...batchSnap.docs);
       }
       snapshot = { docs, size: docs.length };
     } else {
-      // Fetch all workouts for user (both created by and assigned to)
-      const [createdSnap, assignedSnap] = await Promise.all([
-        db.collection('workouts').where('createdBy', '==', userId).get(),
-        db.collection('workouts').where('assignedTo', '==', userId).get(),
-      ]);
-
-      // Deduplicate
-      const docMap = new Map<string, admin.firestore.DocumentSnapshot>();
-      for (const doc of [...createdSnap.docs, ...assignedSnap.docs]) {
-        docMap.set(doc.id, doc);
-      }
-      snapshot = { docs: Array.from(docMap.values()), size: docMap.size };
+      // Fetch all workouts for user from their subcollection
+      const userWorkoutsSnap = await db.collection('users').doc(username).collection('workouts').get();
+      snapshot = { docs: userWorkoutsSnap.docs, size: userWorkoutsSnap.size };
     }
 
     if (snapshot.size === 0) {
@@ -100,7 +95,7 @@ export async function POST(request: NextRequest) {
       const batch = db.batch();
 
       for (const fw of chunk) {
-        const ref = db.collection('workouts').doc(fw.id);
+        const ref = db.collection('users').doc(username).collection('workouts').doc(fw.id);
         batch.update(ref, {
           name: fw.name,
           description: fw.description,

--- a/src/app/api/ai/reports/route.ts
+++ b/src/app/api/ai/reports/route.ts
@@ -3,6 +3,7 @@ export const dynamic = 'force-dynamic';
 import { NextRequest, NextResponse } from 'next/server';
 import Groq from 'groq-sdk';
 import { adminDb } from '@/lib/firebase/admin';
+import { adminResolveUsername } from '@/lib/firebase/adminUserMapping';
 
 const SYSTEM_PROMPT = `You are CoachTrack's AI report generator. Analyze workout data and create beautifully structured reports using JSON format.
 
@@ -83,6 +84,9 @@ export async function POST(req: NextRequest) {
 
     const isCoach = userRole === 'coach';
 
+    // Resolve UID to username
+    const username = await adminResolveUsername(userId);
+
     let dataContext: string;
     let hasData = false;
 
@@ -91,15 +95,9 @@ export async function POST(req: NextRequest) {
       let athleteDocs: FirebaseFirestore.QueryDocumentSnapshot[] = [];
       const coachAthletesSnapshot = await adminDb
         .collection('users')
-        .where('coachId', '==', userId)
+        .where('coachUsername', '==', username)
         .get();
       athleteDocs = coachAthletesSnapshot.docs;
-
-      let workoutsSnapshot;
-      workoutsSnapshot = await adminDb
-        .collection('workouts')
-        .where('createdBy', '==', userId)
-        .get();
 
       const athleteMap = new Map<string, AthleteData>();
       athleteDocs.forEach(doc => {
@@ -116,41 +114,49 @@ export async function POST(req: NextRequest) {
         });
       });
 
+      // Query each athlete's workout subcollection
       const allWorkouts: WorkoutData[] = [];
       const now = new Date();
       const thirtyDaysAgo = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000);
       const sevenDaysAgo = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
       const ninetyDaysAgo = new Date(now.getTime() - 90 * 24 * 60 * 60 * 1000);
 
-      workoutsSnapshot.docs.forEach(doc => {
-        const data = doc.data();
-        const workoutDate = data.date?.toDate ? data.date.toDate() : new Date(data.date);
+      for (const athleteDoc of athleteDocs) {
+        const athleteUsername = athleteDoc.id;
+        const workoutsSnapshot = await adminDb
+          .collection('users').doc(athleteUsername).collection('workouts')
+          .get();
 
-        const workout: WorkoutData = {
-          id: doc.id,
-          name: data.name || 'Unnamed',
-          type: data.type || 'other',
-          date: workoutDate,
-          completed: !!data.completed,
-          completedLate: !!data.completedLate,
-          assignedTo: data.assignedTo || '',
-          duration: data.duration,
-        };
+        workoutsSnapshot.docs.forEach(doc => {
+          const data = doc.data();
+          const workoutDate = data.date?.toDate ? data.date.toDate() : new Date(data.date);
 
-        allWorkouts.push(workout);
+          const workout: WorkoutData = {
+            id: doc.id,
+            name: data.name || 'Unnamed',
+            type: data.type || 'other',
+            date: workoutDate,
+            completed: !!data.completed,
+            completedLate: !!data.completedLate,
+            assignedTo: data.assignedTo || '',
+            duration: data.duration,
+          };
 
-        const athlete = athleteMap.get(workout.assignedTo);
-        if (athlete) {
-          athlete.workouts.push(workout);
-          athlete.totalCount++;
-          if (workout.completed) {
-            athlete.completedCount++;
-            if (workout.completedLate) {
-              athlete.lateCount++;
+          allWorkouts.push(workout);
+
+          const athlete = athleteMap.get(athleteUsername);
+          if (athlete) {
+            athlete.workouts.push(workout);
+            athlete.totalCount++;
+            if (workout.completed) {
+              athlete.completedCount++;
+              if (workout.completedLate) {
+                athlete.lateCount++;
+              }
             }
           }
-        }
-      });
+        });
+      }
 
       athleteMap.forEach(athlete => {
         athlete.completionRate = athlete.totalCount > 0
@@ -217,13 +223,12 @@ ${a.name} (${a.email}):
 Today's Date: ${now.toLocaleDateString()}
 `;
     } else {
-      // Athlete flow - analyze only their own workouts
+      // Athlete flow - analyze only their own workouts (subcollection)
       const workoutsSnapshot = await adminDb
-        .collection('workouts')
-        .where('assignedTo', '==', userId)
+        .collection('users').doc(username).collection('workouts')
         .get();
 
-      const userDoc = await adminDb.collection('users').doc(userId).get();
+      const userDoc = await adminDb.collection('users').doc(username).get();
       const userName = userDoc.exists ? userDoc.data()?.displayName || 'Athlete' : 'Athlete';
 
       const allWorkouts: WorkoutData[] = [];

--- a/src/app/api/ai/route-comment/route.ts
+++ b/src/app/api/ai/route-comment/route.ts
@@ -6,17 +6,17 @@ import Groq from 'groq-sdk';
 
 export async function POST(request: NextRequest) {
   try {
-    const { workoutId } = await request.json();
+    const { workoutId, ownerUsername } = await request.json();
 
-    if (!workoutId) {
-      return NextResponse.json({ error: 'workoutId required' }, { status: 400 });
+    if (!workoutId || !ownerUsername) {
+      return NextResponse.json({ error: 'workoutId and ownerUsername required' }, { status: 400 });
     }
 
     if (!process.env.GROQ_API_KEY) {
       return NextResponse.json({ error: 'GROQ_API_KEY not configured' }, { status: 500 });
     }
 
-    const doc = await adminDb.collection('workouts').doc(workoutId).get();
+    const doc = await adminDb.collection('users').doc(ownerUsername).collection('workouts').doc(workoutId).get();
     if (!doc.exists) {
       return NextResponse.json({ error: 'Workout not found' }, { status: 404 });
     }
@@ -72,7 +72,7 @@ Return ONLY a JSON object: {"comment": "your fun comment here"}`;
       : null;
 
     if (comment) {
-      await adminDb.collection('workouts').doc(workoutId).update({
+      await adminDb.collection('users').doc(ownerUsername).collection('workouts').doc(workoutId).update({
         'routeData.aiComment': comment,
       });
     }

--- a/src/app/api/ai/suggestions/route.ts
+++ b/src/app/api/ai/suggestions/route.ts
@@ -3,6 +3,7 @@ export const dynamic = 'force-dynamic';
 import { NextRequest, NextResponse } from 'next/server';
 import Groq from 'groq-sdk';
 import { adminDb } from '@/lib/firebase/admin';
+import { adminResolveUsername } from '@/lib/firebase/adminUserMapping';
 
 interface StudentStats {
   name: string;
@@ -36,7 +37,9 @@ export async function POST(req: NextRequest) {
       );
     }
 
-    console.log('📊 Generating suggestions for coach:', coachId);
+    // Resolve coach UID to username
+    const coachUsername = await adminResolveUsername(coachId);
+    console.log('📊 Generating suggestions for coach:', coachUsername);
 
     // Get athletes assigned to this coach
     console.log('1️⃣ Fetching athletes...');
@@ -45,7 +48,7 @@ export async function POST(req: NextRequest) {
       // Coach sees only their athletes
       const coachAthletesSnapshot = await adminDb
         .collection('users')
-        .where('coachId', '==', coachId)
+        .where('coachUsername', '==', coachUsername)
         .get();
       allAthleteDocs = coachAthletesSnapshot.docs;
     }
@@ -64,33 +67,26 @@ export async function POST(req: NextRequest) {
       });
     }
 
-    // Get workouts
-    console.log('2️⃣ Fetching workouts...');
-    let workoutsSnapshot;
-    workoutsSnapshot = await adminDb
-      .collection('workouts')
-      .where('createdBy', '==', coachId)
-      .get();
-    console.log('   Found workouts:', workoutsSnapshot.size);
-
-    // Analyze each student
-    console.log('3️⃣ Analyzing student data...');
+    // Analyze each student by querying their workout subcollections
+    console.log('2️⃣ Analyzing student data...');
     const studentStats: StudentStats[] = [];
     const thirtyDaysAgo = new Date();
     thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
 
     for (const studentDoc of allAthleteDocs) {
       const student = studentDoc.data();
-      const studentId = studentDoc.id;
-      console.log(`   Processing student: ${student.displayName || 'Unnamed'} (${studentId})`);
+      const studentUsername = studentDoc.id;
+      console.log(`   Processing student: ${student.displayName || 'Unnamed'} (${studentUsername})`);
 
-      // Get student's workouts with proper typing
-      const studentWorkouts = workoutsSnapshot.docs
+      // Get student's workouts from subcollection
+      const studentWorkoutsSnapshot = await adminDb
+        .collection('users').doc(studentUsername).collection('workouts')
+        .get();
+      const studentWorkouts = studentWorkoutsSnapshot.docs
         .map(doc => ({
           id: doc.id,
           ...doc.data(),
-        }))
-        .filter((w: any) => w.assignedTo === studentId) as any[];
+        })) as any[];
       console.log(`     -> ${studentWorkouts.length} workouts assigned`);
 
       const recentWorkouts = studentWorkouts.filter((w: any) => {

--- a/src/app/api/auth/strava/callback/route.ts
+++ b/src/app/api/auth/strava/callback/route.ts
@@ -3,6 +3,7 @@ export const dynamic = 'force-dynamic';
 import { NextRequest, NextResponse } from 'next/server';
 import { cookies } from 'next/headers';
 import { adminDb } from '@/lib/firebase/admin';
+import { adminResolveUsername } from '@/lib/firebase/adminUserMapping';
 
 export async function GET(request: NextRequest) {
   const baseUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://workout-site-hac0.onrender.com';
@@ -24,18 +25,22 @@ export async function GET(request: NextRequest) {
       );
     }
 
-    // Get userId from cookie
+    // Get userId (UID) from cookie and resolve to username
     const cookieStore = await cookies();
-    const userId = cookieStore.get('strava_oauth_userId')?.value;
-    
-    console.log('🔵 UserId from cookie:', userId);
-    
-    if (!userId) {
+    const uid = cookieStore.get('strava_oauth_userId')?.value;
+
+    console.log('🔵 UID from cookie:', uid);
+
+    if (!uid) {
       console.error('❌ No userId found in cookie');
       return NextResponse.redirect(
         new URL('/settings?strava=error&reason=no_cookie', baseUrl)
       );
     }
+
+    // Resolve UID to username for the new schema
+    const username = await adminResolveUsername(uid);
+    console.log('🔵 Resolved username:', username);
 
     console.log('🔐 Exchanging code for tokens...');
     console.log('🔵 Client ID:', process.env.STRAVA_CLIENT_ID);
@@ -67,7 +72,7 @@ export async function GET(request: NextRequest) {
     console.log('✅ Received tokens, athlete ID:', tokenData.athlete?.id);
 
     // Store tokens in Firestore
-    await adminDb.collection('users').doc(userId).update({
+    await adminDb.collection('users').doc(username).update({
       stravaConnected: true,
       stravaId: String(tokenData.athlete.id),
       stravaAccessToken: tokenData.access_token,
@@ -84,7 +89,7 @@ export async function GET(request: NextRequest) {
       stravaConnectedAt: new Date(),
     });
 
-    console.log('✅ Strava tokens saved for user:', userId);
+    console.log('✅ Strava tokens saved for user:', username);
 
     // Clear the cookie
     cookieStore.delete('strava_oauth_userId');

--- a/src/app/api/cron/send-reminders/route.ts
+++ b/src/app/api/cron/send-reminders/route.ts
@@ -15,6 +15,7 @@ interface WorkoutData {
   date: admin.firestore.Timestamp;
   duration?: number;
   assignedTo: string;
+  ownerUsername: string;
   completed: boolean;
   reminderSent?: boolean;
 }
@@ -24,9 +25,9 @@ interface UserData {
   displayName: string;
 }
 
-async function getUserData(userId: string): Promise<UserData | null> {
+async function getUserData(username: string): Promise<UserData | null> {
   try {
-    const userDoc = await adminDb.collection('users').doc(userId).get();
+    const userDoc = await adminDb.collection('users').doc(username).get();
     if (userDoc.exists) {
       const data = userDoc.data();
       return {
@@ -183,7 +184,7 @@ export async function GET(request: NextRequest) {
 
     // Get tomorrow's incomplete workouts that haven't been reminded
     const workoutsSnapshot = await adminDb
-      .collection('workouts')
+      .collectionGroup('workouts')
       .where('date', '>=', admin.firestore.Timestamp.fromDate(tomorrowStart))
       .where('date', '<=', admin.firestore.Timestamp.fromDate(tomorrowEnd))
       .where('completed', '==', false)
@@ -230,8 +231,9 @@ export async function GET(request: NextRequest) {
       );
 
       if (sent) {
-        // Mark as reminded
-        await adminDb.collection('workouts').doc(workout.id).update({
+        // Mark as reminded (subcollection path: users/{username}/workouts/{id})
+        const ownerUsername = workout.ownerUsername || workout.assignedTo;
+        await adminDb.collection('users').doc(ownerUsername).collection('workouts').doc(workout.id).update({
           reminderSent: true,
         });
 

--- a/src/app/api/cron/send-summaries/route.ts
+++ b/src/app/api/cron/send-summaries/route.ts
@@ -20,11 +20,11 @@ function getISTStartOfDay(date: Date): Date {
 }
 
 interface UserData {
-  uid: string;
+  username: string;
   email: string;
   displayName: string;
   lastSummaryDate?: admin.firestore.Timestamp;
-  coachId?: string;
+  coachUsername?: string;
   stravaConnected?: boolean;
   createdAt?: admin.firestore.Timestamp;
 }
@@ -39,9 +39,9 @@ interface WorkoutData {
   };
 }
 
-async function getCoachEmail(coachId: string): Promise<string | null> {
+async function getCoachEmail(coachUsername: string): Promise<string | null> {
   try {
-    const coachDoc = await adminDb.collection('users').doc(coachId).get();
+    const coachDoc = await adminDb.collection('users').doc(coachUsername).get();
     if (coachDoc.exists) {
       return coachDoc.data()?.email || null;
     }
@@ -114,8 +114,8 @@ export async function GET(request: NextRequest) {
     const eligibleUsers: UserData[] = [];
 
     for (const doc of allUserDocs) {
-      const userData = doc.data() as Omit<UserData, 'uid'>;
-      const user: UserData = { uid: doc.id, ...userData };
+      const userData = doc.data() as Omit<UserData, 'username'>;
+      const user: UserData = { username: doc.id, ...userData };
 
       // Skip if no email
       if (!user.email) continue;
@@ -156,10 +156,9 @@ export async function GET(request: NextRequest) {
 
     for (const user of eligibleUsers) {
       try {
-        // Get user's workouts from the period
+        // Get user's workouts from the period (subcollection scoped to user)
         const workoutsSnapshot = await adminDb
-          .collection('workouts')
-          .where('assignedTo', '==', user.uid)
+          .collection('users').doc(user.username).collection('workouts')
           .where('date', '>=', admin.firestore.Timestamp.fromDate(periodStart))
           .where('date', '<=', admin.firestore.Timestamp.fromDate(now))
           .get();
@@ -207,8 +206,8 @@ export async function GET(request: NextRequest) {
 
         // Get coach email for CC
         let coachEmail: string | null = null;
-        if (user.coachId) {
-          coachEmail = await getCoachEmail(user.coachId);
+        if (user.coachUsername) {
+          coachEmail = await getCoachEmail(user.coachUsername);
         }
 
         // Prepare summary data
@@ -228,7 +227,7 @@ export async function GET(request: NextRequest) {
 
         if (sent) {
           // Update lastSummaryDate
-          await adminDb.collection('users').doc(user.uid).update({
+          await adminDb.collection('users').doc(user.username).update({
             lastSummaryDate: admin.firestore.FieldValue.serverTimestamp(),
           });
 

--- a/src/app/api/debug/list-users/route.ts
+++ b/src/app/api/debug/list-users/route.ts
@@ -5,7 +5,7 @@ export async function GET() {
   const snap = await adminDb.collection('users').get();
   const users = snap.docs.map(d => {
     const data = d.data();
-    return { uid: d.id, email: data.email, role: data.role, strava: !!data.stravaId };
+    return { username: d.id, email: data.email, role: data.role, strava: !!data.stravaId };
   });
   return NextResponse.json(users);
 }

--- a/src/app/api/export/workouts/route.ts
+++ b/src/app/api/export/workouts/route.ts
@@ -4,6 +4,7 @@ export const dynamic = 'force-dynamic';
 import { timingSafeEqual } from 'node:crypto';
 import { NextRequest, NextResponse } from 'next/server';
 import { getFirebaseAdminDb } from '@/lib/firebase-admin';
+import { adminResolveUsername } from '@/lib/firebase/adminUserMapping';
 
 // ─── Value helpers (same as MCP route) ───────────────────────────────────────
 
@@ -120,16 +121,14 @@ export async function GET(request: NextRequest) {
 
     const userDoc = usersSnapshot.docs[0];
     const userData = userDoc.data();
-    const userId = userDoc.id;
+    const username = userDoc.id; // doc.id is now username
 
-    // 2. Query workouts
-    let workoutsQuery = db.collection('workouts')
-      .where('assignedTo', '==', userId)
-      .orderBy('date', 'desc');
+    // 2. Query workouts from subcollection
+    const workoutsCol = db.collection('users').doc(username).collection('workouts');
+    let workoutsQuery = workoutsCol.orderBy('date', 'desc');
 
     if (!includeAll) {
-      workoutsQuery = db.collection('workouts')
-        .where('assignedTo', '==', userId)
+      workoutsQuery = workoutsCol
         .where('completed', '==', false)
         .orderBy('date', 'desc');
     }
@@ -142,7 +141,7 @@ export async function GET(request: NextRequest) {
     // 3. Return JSON
     return NextResponse.json({
       user: {
-        uid: userId,
+        username,
         email: userData.email ?? email,
         displayName: userData.displayName ?? null,
         role: userData.role ?? null,

--- a/src/app/api/import/confirm/route.ts
+++ b/src/app/api/import/confirm/route.ts
@@ -3,6 +3,7 @@ import { getAdminDb } from '@/lib/firebase/admin';
 import { SerializedWorkout } from '@/lib/import/types';
 import { enrichWorkouts } from '@/lib/import/enricher';
 import * as admin from 'firebase-admin';
+import { adminResolveUsername } from '@/lib/firebase/adminUserMapping';
 
 export async function POST(request: NextRequest) {
   try {
@@ -19,6 +20,9 @@ export async function POST(request: NextRequest) {
     }
 
     const db = getAdminDb();
+
+    // Resolve UID to username
+    const username = await adminResolveUsername(userId);
     const sessionDoc = await db.collection('importSessions').doc(sessionId).get();
 
     if (!sessionDoc.exists) {
@@ -56,7 +60,7 @@ export async function POST(request: NextRequest) {
       const batch = db.batch();
 
       for (const workout of chunk) {
-        const ref = db.collection('workouts').doc();
+        const ref = db.collection('users').doc(username).collection('workouts').doc();
         createdIds.push(ref.id);
 
         // Apply Groq enrichments (better names, descriptions, tags)
@@ -76,8 +80,9 @@ export async function POST(request: NextRequest) {
             completedBy: 'import',
           } : {}),
           source: 'import',
-          createdBy: userId,
-          assignedTo: userId,
+          ownerUsername: username,
+          createdBy: username,
+          assignedTo: username,
           assignedToName: userName || '',
           tags: enriched?.tags?.length ? enriched.tags : (workout.tags || []),
           createdAt: admin.firestore.FieldValue.serverTimestamp(),

--- a/src/app/api/mcp/route.ts
+++ b/src/app/api/mcp/route.ts
@@ -8,6 +8,7 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { WebStandardStreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js';
 import * as z from 'zod/v4';
 import { getFirebaseAdminDb } from '@/lib/firebase-admin';
+import { adminResolveUsername } from '@/lib/firebase/adminUserMapping';
 
 const DEFAULT_WORKOUT_LIMIT = 20;
 const MAX_WORKOUT_LIMIT = 50;
@@ -43,11 +44,11 @@ interface SafeWorkout {
 }
 
 interface SafeUser {
-  uid: string;
+  username: string;
   displayName: string | null;
   email: string | null;
   role: string | null;
-  coachId: string | null;
+  coachUsername: string | null;
   createdAt: string | null;
   onboardingCompleted: boolean;
   stravaConnected: boolean;
@@ -108,17 +109,47 @@ function toSafeWorkout(id: string, data: WorkoutDoc): SafeWorkout {
   };
 }
 
-function toSafeUser(uid: string, data: UserDoc): SafeUser {
+function toSafeUser(username: string, data: UserDoc): SafeUser {
   return {
-    uid,
+    username,
     displayName: toOptionalString(data.displayName),
     email: toOptionalString(data.email),
     role: toOptionalString(data.role),
-    coachId: toOptionalString(data.coachId),
+    coachUsername: toOptionalString(data.coachUsername),
     createdAt: toIsoString(data.createdAt),
     onboardingCompleted: data.onboardingCompleted === true,
     stravaConnected: typeof data.stravaId === 'string' && data.stravaId.length > 0,
   };
+}
+
+// ─── Workout lookup helper ────────────────────────────────────────────────────
+
+/**
+ * Find a workout document by its ID across all user subcollections.
+ * If ownerUsername is provided, uses direct path lookup (fast).
+ * Otherwise falls back to collectionGroup scan (admin MCP tool, acceptable perf).
+ */
+async function getWorkoutDocById(
+  db: FirebaseFirestore.Firestore,
+  workoutId: string,
+  ownerUsername?: string,
+) {
+  // Fast path: direct lookup if owner is known
+  if (ownerUsername) {
+    const ref = db.collection('users').doc(ownerUsername).collection('workouts').doc(workoutId);
+    const doc = await ref.get();
+    if (doc.exists) return { doc, ref };
+    return null;
+  }
+
+  // Slow path: scan collectionGroup (admin MCP tool, acceptable)
+  const snap = await db.collectionGroup('workouts').get();
+  for (const doc of snap.docs) {
+    if (doc.id === workoutId) {
+      return { doc, ref: doc.ref };
+    }
+  }
+  return null;
 }
 
 // ─── Auth helpers ─────────────────────────────────────────────────────────────
@@ -155,23 +186,29 @@ function createMcpServer(): McpServer {
     'get_user_workouts',
     {
       title: 'Get User Workouts',
-      description: 'Fetches recent workouts. Pass userId to filter by user, or omit for all users.',
+      description: 'Fetches recent workouts. Pass username to filter by user, or omit for all users.',
       inputSchema: {
-        userId: z.string().min(1).max(128).regex(/^[A-Za-z0-9_-]+$/).optional(),
+        username: z.string().min(1).max(128).regex(/^[A-Za-z0-9_-]+$/).optional(),
         limit: z.number().int().min(1).max(MAX_WORKOUT_LIMIT).default(DEFAULT_WORKOUT_LIMIT),
       },
     },
-    async (input: { userId?: string; limit?: number }) => {
-      const { userId, limit = DEFAULT_WORKOUT_LIMIT } = input;
-      const col = db.collection('workouts');
-      const snapshot = userId
-        ? await col.where('assignedTo', '==', userId).orderBy('date', 'desc').limit(limit).get()
-        : await col.orderBy('date', 'desc').limit(limit).get();
+    async (input: { username?: string; limit?: number }) => {
+      const { username, limit = DEFAULT_WORKOUT_LIMIT } = input;
+      let snapshot;
+      if (username) {
+        // Query from user's workout subcollection
+        snapshot = await db.collection('users').doc(username).collection('workouts')
+          .orderBy('date', 'desc').limit(limit).get();
+      } else {
+        // Query across all users via collectionGroup
+        snapshot = await db.collectionGroup('workouts')
+          .orderBy('date', 'desc').limit(limit).get();
+      }
       const workouts = snapshot.docs.map((d) => toSafeWorkout(d.id, d.data() as WorkoutDoc));
       return {
         content: [{
           type: 'text',
-          text: JSON.stringify({ scope: userId ? 'single_user' : 'all_users', userId: userId ?? null, count: workouts.length, workouts }, null, 2),
+          text: JSON.stringify({ scope: username ? 'single_user' : 'all_users', username: username ?? null, count: workouts.length, workouts }, null, 2),
         }],
       };
     }
@@ -182,17 +219,18 @@ function createMcpServer(): McpServer {
     'get_workout_detail',
     {
       title: 'Get Workout Detail',
-      description: 'Returns full details of a single workout by ID, including all sport-specific fields.',
+      description: 'Returns full details of a single workout by ID, including all sport-specific fields. Provide ownerUsername for faster lookup.',
       inputSchema: {
         workoutId: z.string().min(1).max(128),
+        ownerUsername: z.string().min(1).max(128).optional(),
       },
     },
-    async (input: { workoutId: string }) => {
-      const docSnap = await db.collection('workouts').doc(input.workoutId).get();
-      if (!docSnap.exists) {
+    async (input: { workoutId: string; ownerUsername?: string }) => {
+      const result = await getWorkoutDocById(db, input.workoutId, input.ownerUsername);
+      if (!result) {
         return { content: [{ type: 'text', text: JSON.stringify({ error: 'Workout not found' }) }] };
       }
-      const workout = toSafeWorkout(docSnap.id, docSnap.data() as WorkoutDoc);
+      const workout = toSafeWorkout(result.doc.id, result.doc.data() as WorkoutDoc);
       return { content: [{ type: 'text', text: JSON.stringify(workout, null, 2) }] };
     }
   );
@@ -232,7 +270,7 @@ function createMcpServer(): McpServer {
     async () => {
       const [usersSnap, workoutsSnap] = await Promise.all([
         db.collection('users').get(),
-        db.collection('workouts').get(),
+        db.collectionGroup('workouts').get(),
       ]);
 
       const roleCount: Record<string, number> = {};
@@ -280,8 +318,8 @@ function createMcpServer(): McpServer {
         name: z.string().min(1).max(200),
         type: z.enum(['swim', 'bike', 'run', 'strength', 'other']),
         date: z.string().describe('ISO 8601 date string, e.g. 2026-03-01T18:30:00.000Z'),
-        assignedTo: z.string().min(1).max(128).describe('UID of the athlete to assign to'),
-        createdBy: z.string().min(1).max(128).describe('UID of the coach/creator'),
+        assignedTo: z.string().min(1).max(128).describe('Username of the athlete to assign to'),
+        createdBy: z.string().min(1).max(128).describe('Username of the coach/creator'),
         description: z.string().max(2000).optional(),
         duration: z.number().int().min(1).optional().describe('Duration in minutes'),
         tags: z.array(z.string()).optional(),
@@ -295,10 +333,12 @@ function createMcpServer(): McpServer {
       if (isNaN(date.getTime())) {
         return { content: [{ type: 'text', text: JSON.stringify({ error: 'Invalid date format' }) }] };
       }
+      const ownerUsername = input.assignedTo;
       const data: Record<string, unknown> = {
         name: input.name,
         type: input.type,
         date: date,
+        ownerUsername,
         assignedTo: input.assignedTo,
         createdBy: input.createdBy,
         completed: false,
@@ -309,7 +349,7 @@ function createMcpServer(): McpServer {
       if (input.duration) data.duration = input.duration;
       if (input.tags?.length) data.tags = input.tags;
 
-      const ref = await db.collection('workouts').add(data);
+      const ref = await db.collection('users').doc(ownerUsername).collection('workouts').add(data);
       return { content: [{ type: 'text', text: JSON.stringify({ success: true, workoutId: ref.id }) }] };
     }
   );
@@ -319,9 +359,10 @@ function createMcpServer(): McpServer {
     'update_workout',
     {
       title: 'Update Workout',
-      description: 'Updates fields on an existing workout. Only the fields you provide will be changed.',
+      description: 'Updates fields on an existing workout. Only the fields you provide will be changed. Provide ownerUsername for faster lookup.',
       inputSchema: {
         workoutId: z.string().min(1).max(128),
+        ownerUsername: z.string().min(1).max(128).optional(),
         name: z.string().min(1).max(200).optional(),
         description: z.string().max(2000).optional(),
         date: z.string().optional().describe('ISO 8601 date string'),
@@ -331,13 +372,12 @@ function createMcpServer(): McpServer {
       },
     },
     async (input: {
-      workoutId: string; name?: string; description?: string; date?: string;
+      workoutId: string; ownerUsername?: string; name?: string; description?: string; date?: string;
       duration?: number; tags?: string[]; type?: string;
     }) => {
-      const { workoutId, ...rest } = input;
-      const docRef = db.collection('workouts').doc(workoutId);
-      const snap = await docRef.get();
-      if (!snap.exists) {
+      const { workoutId, ownerUsername, ...rest } = input;
+      const result = await getWorkoutDocById(db, workoutId, ownerUsername);
+      if (!result) {
         return { content: [{ type: 'text', text: JSON.stringify({ error: 'Workout not found' }) }] };
       }
       const updates: Record<string, unknown> = { updatedAt: FieldValue.serverTimestamp() };
@@ -353,7 +393,7 @@ function createMcpServer(): McpServer {
         }
         updates.date = d;
       }
-      await docRef.update(updates);
+      await result.ref.update(updates);
       return { content: [{ type: 'text', text: JSON.stringify({ success: true, workoutId }) }] };
     }
   );
@@ -363,18 +403,18 @@ function createMcpServer(): McpServer {
     'delete_workout',
     {
       title: 'Delete Workout',
-      description: 'Permanently deletes a workout by ID. This cannot be undone.',
+      description: 'Permanently deletes a workout by ID. This cannot be undone. Provide ownerUsername for faster lookup.',
       inputSchema: {
         workoutId: z.string().min(1).max(128),
+        ownerUsername: z.string().min(1).max(128).optional(),
       },
     },
-    async (input: { workoutId: string }) => {
-      const docRef = db.collection('workouts').doc(input.workoutId);
-      const snap = await docRef.get();
-      if (!snap.exists) {
+    async (input: { workoutId: string; ownerUsername?: string }) => {
+      const result = await getWorkoutDocById(db, input.workoutId, input.ownerUsername);
+      if (!result) {
         return { content: [{ type: 'text', text: JSON.stringify({ error: 'Workout not found' }) }] };
       }
-      await docRef.delete();
+      await result.ref.delete();
       return { content: [{ type: 'text', text: JSON.stringify({ success: true, deleted: input.workoutId }) }] };
     }
   );
@@ -384,17 +424,17 @@ function createMcpServer(): McpServer {
     'complete_workout',
     {
       title: 'Complete / Uncomplete Workout',
-      description: 'Marks a workout as completed or resets it to incomplete.',
+      description: 'Marks a workout as completed or resets it to incomplete. Provide ownerUsername for faster lookup.',
       inputSchema: {
         workoutId: z.string().min(1).max(128),
+        ownerUsername: z.string().min(1).max(128).optional(),
         completed: z.boolean(),
         notes: z.string().max(2000).optional(),
       },
     },
-    async (input: { workoutId: string; completed: boolean; notes?: string }) => {
-      const docRef = db.collection('workouts').doc(input.workoutId);
-      const snap = await docRef.get();
-      if (!snap.exists) {
+    async (input: { workoutId: string; ownerUsername?: string; completed: boolean; notes?: string }) => {
+      const result = await getWorkoutDocById(db, input.workoutId, input.ownerUsername);
+      if (!result) {
         return { content: [{ type: 'text', text: JSON.stringify({ error: 'Workout not found' }) }] };
       }
       const updates: Record<string, unknown> = {
@@ -405,7 +445,7 @@ function createMcpServer(): McpServer {
         updates.completedAt = FieldValue.serverTimestamp();
         updates.completedBy = 'mcp';
         if (input.notes) updates.completionNotes = input.notes;
-        const workoutDate = toIsoString((snap.data() as WorkoutDoc).date);
+        const workoutDate = toIsoString((result.doc.data() as WorkoutDoc).date);
         if (workoutDate) {
           updates.completedLate = new Date() > new Date(workoutDate);
         }
@@ -415,7 +455,7 @@ function createMcpServer(): McpServer {
         updates.completionNotes = null;
         updates.completedLate = null;
       }
-      await docRef.update(updates);
+      await result.ref.update(updates);
       return { content: [{ type: 'text', text: JSON.stringify({ success: true, workoutId: input.workoutId, completed: input.completed }) }] };
     }
   );
@@ -425,15 +465,18 @@ function createMcpServer(): McpServer {
     'get_workout_comments',
     {
       title: 'Get Workout Comments',
-      description: 'Returns all comments on a workout, ordered by creation time.',
+      description: 'Returns all comments on a workout, ordered by creation time. Provide ownerUsername for faster lookup.',
       inputSchema: {
         workoutId: z.string().min(1).max(128),
+        ownerUsername: z.string().min(1).max(128).optional(),
       },
     },
-    async (input: { workoutId: string }) => {
-      const snapshot = await db
-        .collection('workouts')
-        .doc(input.workoutId)
+    async (input: { workoutId: string; ownerUsername?: string }) => {
+      const result = await getWorkoutDocById(db, input.workoutId, input.ownerUsername);
+      if (!result) {
+        return { content: [{ type: 'text', text: JSON.stringify({ error: 'Workout not found' }) }] };
+      }
+      const snapshot = await result.ref
         .collection('comments')
         .orderBy('createdAt', 'asc')
         .get();
@@ -459,9 +502,10 @@ function createMcpServer(): McpServer {
     'add_workout_comment',
     {
       title: 'Add Workout Comment',
-      description: 'Posts a comment on a workout. Use this for AI coaching feedback.',
+      description: 'Posts a comment on a workout. Use this for AI coaching feedback. Provide ownerUsername for faster lookup.',
       inputSchema: {
         workoutId: z.string().min(1).max(128),
+        ownerUsername: z.string().min(1).max(128).optional(),
         userId: z.string().min(1).max(128),
         userName: z.string().min(1).max(100),
         userRole: z.enum(['coach', 'athlete', 'student']),
@@ -470,9 +514,13 @@ function createMcpServer(): McpServer {
       },
     },
     async (input: {
-      workoutId: string; userId: string; userName: string;
+      workoutId: string; ownerUsername?: string; userId: string; userName: string;
       userRole: string; text: string; rating?: string;
     }) => {
+      const result = await getWorkoutDocById(db, input.workoutId, input.ownerUsername);
+      if (!result) {
+        return { content: [{ type: 'text', text: JSON.stringify({ error: 'Workout not found' }) }] };
+      }
       const data: Record<string, unknown> = {
         workoutId: input.workoutId,
         userId: input.userId,
@@ -482,9 +530,7 @@ function createMcpServer(): McpServer {
         createdAt: FieldValue.serverTimestamp(),
       };
       if (input.rating) data.rating = input.rating;
-      const ref = await db
-        .collection('workouts')
-        .doc(input.workoutId)
+      const ref = await result.ref
         .collection('comments')
         .add(data);
       return { content: [{ type: 'text', text: JSON.stringify({ success: true, commentId: ref.id }) }] };
@@ -535,11 +581,11 @@ function createMcpServer(): McpServer {
     },
     async () => {
       const [workoutsSnap, usersSnap] = await Promise.all([
-        db.collection('workouts').orderBy('date', 'desc').limit(500).get(),
+        db.collectionGroup('workouts').orderBy('date', 'desc').limit(500).get(),
         db.collection('users').get(),
       ]);
 
-      const userIds = new Set(usersSnap.docs.map((d) => d.id));
+      const usernames = new Set(usersSnap.docs.map((d) => d.id));
       const issues: { workoutId: string; issue: string; severity: 'warning' | 'error' }[] = [];
       const now = new Date();
       const thirtyDaysAgo = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000);
@@ -555,7 +601,7 @@ function createMcpServer(): McpServer {
         if (!w.date) issues.push({ workoutId: id, issue: 'Missing date', severity: 'error' });
 
         // Orphaned assignment
-        if (typeof w.assignedTo === 'string' && w.assignedTo && !userIds.has(w.assignedTo)) {
+        if (typeof w.assignedTo === 'string' && w.assignedTo && !usernames.has(w.assignedTo)) {
           issues.push({ workoutId: id, issue: `assignedTo user "${w.assignedTo}" does not exist`, severity: 'warning' });
         }
 

--- a/src/app/api/notifications/workout-comment/route.ts
+++ b/src/app/api/notifications/workout-comment/route.ts
@@ -7,6 +7,7 @@ import { WorkoutRating } from '@/types';
 
 interface CommentNotificationPayload {
   workoutId: string;
+  ownerUsername: string;
   workoutName: string;
   commentText: string;
   studentName: string;
@@ -100,30 +101,30 @@ function generateNotificationEmail(
 export async function POST(request: NextRequest) {
   try {
     const body: CommentNotificationPayload = await request.json();
-    const { workoutId, workoutName, commentText, studentName, rating } = body;
+    const { workoutId, ownerUsername, workoutName, commentText, studentName, rating } = body;
 
-    if (!workoutId || !commentText || !studentName) {
+    if (!workoutId || !ownerUsername || !commentText || !studentName) {
       return NextResponse.json(
         { error: 'Missing required fields' },
         { status: 400 }
       );
     }
 
-    // Get the workout to find the coach
-    const workoutDoc = await adminDb.collection('workouts').doc(workoutId).get();
+    // Get the workout to find the coach (subcollection path)
+    const workoutDoc = await adminDb.collection('users').doc(ownerUsername).collection('workouts').doc(workoutId).get();
     if (!workoutDoc.exists) {
       return NextResponse.json({ error: 'Workout not found' }, { status: 404 });
     }
 
     const workoutData = workoutDoc.data();
-    const coachId = workoutData?.createdBy;
+    const coachUsername = workoutData?.createdBy;
 
-    if (!coachId) {
+    if (!coachUsername) {
       return NextResponse.json({ error: 'No coach found' }, { status: 404 });
     }
 
     // Get coach data
-    const coachDoc = await adminDb.collection('users').doc(coachId).get();
+    const coachDoc = await adminDb.collection('users').doc(coachUsername).get();
     if (!coachDoc.exists) {
       return NextResponse.json({ error: 'Coach not found' }, { status: 404 });
     }

--- a/src/app/api/reports/send/route.ts
+++ b/src/app/api/reports/send/route.ts
@@ -5,20 +5,21 @@ import { adminDb } from '@/lib/firebase/admin';
 import admin from 'firebase-admin';
 import * as brevo from '@getbrevo/brevo';
 import { generateSummaryEmail, generateSummarySubject, SummaryData } from '@/lib/email/summaryTemplate';
+import { adminResolveUsername } from '@/lib/firebase/adminUserMapping';
 
 interface RequestBody {
   userId?: string;
   periodDays?: number;
 }
 
-async function buildSummary(userId: string, periodDays: number): Promise<{ summary: SummaryData; coachEmail?: string | null } | null> {
-  const userDoc = await adminDb.collection('users').doc(userId).get();
+async function buildSummary(username: string, periodDays: number): Promise<{ summary: SummaryData; coachEmail?: string | null } | null> {
+  const userDoc = await adminDb.collection('users').doc(username).get();
   if (!userDoc.exists) return null;
 
   const userData = userDoc.data() as any;
   const userEmail = userData.email as string | undefined;
   const userName = userData.displayName || 'Athlete';
-  const coachId = userData.coachId as string | undefined;
+  const coachUsername = userData.coachUsername as string | undefined;
 
   if (!userEmail) return null;
 
@@ -27,8 +28,7 @@ async function buildSummary(userId: string, periodDays: number): Promise<{ summa
   const periodStart = new Date(now.getTime() - periodDays * 24 * 60 * 60 * 1000);
 
   const workoutsSnapshot = await adminDb
-    .collection('workouts')
-    .where('assignedTo', '==', userId)
+    .collection('users').doc(username).collection('workouts')
     .where('date', '>=', admin.firestore.Timestamp.fromDate(periodStart))
     .where('date', '<=', admin.firestore.Timestamp.fromDate(now))
     .get();
@@ -77,8 +77,8 @@ async function buildSummary(userId: string, periodDays: number): Promise<{ summa
   };
 
   let coachEmail: string | null = null;
-  if (coachId) {
-    const coachDoc = await adminDb.collection('users').doc(coachId).get();
+  if (coachUsername) {
+    const coachDoc = await adminDb.collection('users').doc(coachUsername).get();
     if (coachDoc.exists) coachEmail = (coachDoc.data() as any)?.email || null;
   }
 
@@ -115,12 +115,15 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ success: false, error: 'userId is required' }, { status: 400 });
     }
 
-    const summaryResult = await buildSummary(userId, periodDays);
+    // Resolve UID to username
+    const username = await adminResolveUsername(userId);
+
+    const summaryResult = await buildSummary(username, periodDays);
     if (!summaryResult) {
       return NextResponse.json({ success: false, error: 'No workouts or user/email not found' }, { status: 404 });
     }
 
-    const userDoc = await adminDb.collection('users').doc(userId).get();
+    const userDoc = await adminDb.collection('users').doc(username).get();
     const userData = userDoc.data() as any;
     const userEmail = userData.email as string | undefined;
     const userName = userData.displayName || 'Athlete';
@@ -131,7 +134,7 @@ export async function POST(request: NextRequest) {
 
     await sendEmail(userEmail, userName, summaryResult.summary, summaryResult.coachEmail);
 
-    await adminDb.collection('users').doc(userId).update({ lastSummaryDate: admin.firestore.FieldValue.serverTimestamp() });
+    await adminDb.collection('users').doc(username).update({ lastSummaryDate: admin.firestore.FieldValue.serverTimestamp() });
 
     return NextResponse.json({ success: true });
   } catch (error: any) {

--- a/src/app/api/send-workout-email/route.ts
+++ b/src/app/api/send-workout-email/route.ts
@@ -19,7 +19,7 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'Invalid request body' }, { status: 400 });
     }
 
-    const { studentEmail, studentName, workout, workoutId } = body;
+    const { studentEmail, studentName, workout, workoutId, ownerUsername } = body;
 
     if (!studentEmail || !workout) {
       return NextResponse.json(
@@ -116,7 +116,7 @@ export async function POST(request: NextRequest) {
 
               <!-- CTA -->
               <div style="text-align: center; margin-top: 30px;">
-                <a href="${process.env.NEXT_PUBLIC_APP_URL || 'https://ryanssareen-workout-site-k6vl.vercel.app'}${workoutId ? `/preview/${workoutId}` : '/workouts'}" style="display: inline-block; background-color: #dc2626; color: #ffffff; padding: 16px 48px; text-decoration: none; border-radius: 8px; font-weight: 800; font-size: 15px; text-transform: uppercase; letter-spacing: 1px;">
+                <a href="${process.env.NEXT_PUBLIC_APP_URL || 'https://ryanssareen-workout-site-k6vl.vercel.app'}${workoutId && ownerUsername ? `/preview/${ownerUsername}/${workoutId}` : '/workouts'}" style="display: inline-block; background-color: #dc2626; color: #ffffff; padding: 16px 48px; text-decoration: none; border-radius: 8px; font-weight: 800; font-size: 15px; text-transform: uppercase; letter-spacing: 1px;">
                   View Workout
                 </a>
               </div>

--- a/src/app/api/strava/cleanup/route.ts
+++ b/src/app/api/strava/cleanup/route.ts
@@ -32,8 +32,7 @@ export async function GET(request: NextRequest) {
 
     // Get all Strava workouts for this user
     const workoutsSnapshot = await adminDb
-      .collection('workouts')
-      .where('assignedTo', '==', userId)
+      .collection('users').doc(userId).collection('workouts')
       .where('source', '==', 'strava')
       .get();
 
@@ -80,7 +79,7 @@ export async function GET(request: NextRequest) {
       const batch = adminDb.batch();
 
       for (const docId of chunk) {
-        batch.delete(adminDb.collection('workouts').doc(docId));
+        batch.delete(adminDb.collection('users').doc(userId).collection('workouts').doc(docId));
       }
 
       await batch.commit();

--- a/src/app/api/strava/migrate-photos/route.ts
+++ b/src/app/api/strava/migrate-photos/route.ts
@@ -58,7 +58,7 @@ export async function POST(request: NextRequest) {
 
     // Get Strava workouts that don't have photos field yet
     const workoutsSnapshot = await adminDb
-      .collection('workouts')
+      .collectionGroup('workouts')
       .where('source', '==', 'strava')
       .limit(500)
       .get();
@@ -79,13 +79,13 @@ export async function POST(request: NextRequest) {
       });
     }
 
-    // Group by user to reuse tokens
+    // Group by user (ownerUsername) to reuse tokens
     const byUser: Record<string, any[]> = {};
     for (const doc of workoutsToCheck) {
       const data = doc.data();
-      const userId = data.assignedTo;
-      if (!byUser[userId]) byUser[userId] = [];
-      byUser[userId].push({ id: doc.id, ...data });
+      const ownerUsername = data.ownerUsername || data.assignedTo;
+      if (!byUser[ownerUsername]) byUser[ownerUsername] = [];
+      byUser[ownerUsername].push({ id: doc.id, ref: doc.ref, ...data });
     }
 
     let updated = 0;
@@ -120,7 +120,7 @@ export async function POST(request: NextRequest) {
             console.log(`❌ ${workout.name}: ${response.status}`);
 
             if (response.status !== 429) {
-              await adminDb.collection('workouts').doc(workout.id).update({
+              await workout.ref.update({
                 photosChecked: true,
               });
             }
@@ -145,14 +145,14 @@ export async function POST(request: NextRequest) {
           }
 
           if (urls.length > 0) {
-            await adminDb.collection('workouts').doc(workout.id).update({
+            await workout.ref.update({
               photos: urls,
               photosChecked: true,
             });
             updated++;
             console.log(`✅ ${workout.name}: ${urls.length} photos`);
           } else {
-            await adminDb.collection('workouts').doc(workout.id).update({
+            await workout.ref.update({
               photosChecked: true,
             });
             noPhotos++;
@@ -170,7 +170,7 @@ export async function POST(request: NextRequest) {
 
     // Count remaining
     const remainingSnapshot = await adminDb
-      .collection('workouts')
+      .collectionGroup('workouts')
       .where('source', '==', 'strava')
       .limit(500)
       .get();

--- a/src/app/api/strava/migrate-routes/route.ts
+++ b/src/app/api/strava/migrate-routes/route.ts
@@ -58,7 +58,7 @@ export async function POST(request: NextRequest) {
 
     // Get all Strava workouts WITHOUT routeData, limited
     const workoutsSnapshot = await adminDb
-      .collection('workouts')
+      .collectionGroup('workouts')
       .where('source', '==', 'strava')
       .limit(500) // Get more to filter
       .get();
@@ -80,13 +80,13 @@ export async function POST(request: NextRequest) {
       });
     }
 
-    // Group by user to reuse tokens
+    // Group by user (ownerUsername) to reuse tokens
     const byUser: Record<string, any[]> = {};
     for (const doc of workoutsToUpdate) {
       const data = doc.data();
-      const userId = data.assignedTo;
-      if (!byUser[userId]) byUser[userId] = [];
-      byUser[userId].push({ id: doc.id, ...data });
+      const ownerUsername = data.ownerUsername || data.assignedTo;
+      if (!byUser[ownerUsername]) byUser[ownerUsername] = [];
+      byUser[ownerUsername].push({ id: doc.id, ref: doc.ref, ...data });
     }
 
     let updated = 0;
@@ -124,8 +124,8 @@ export async function POST(request: NextRequest) {
             
             // Mark as failed so we don't retry forever (except rate limits)
             if (response.status !== 429) {
-              await adminDb.collection('workouts').doc(workout.id).update({ 
-                routeData: { failed: true, error: response.status } 
+              await workout.ref.update({
+                routeData: { failed: true, error: response.status }
               });
             }
             
@@ -152,13 +152,13 @@ export async function POST(request: NextRequest) {
           }
 
           if (routeData.polyline) {
-            await adminDb.collection('workouts').doc(workout.id).update({ routeData });
+            await workout.ref.update({ routeData });
             updated++;
             console.log(`✅ ${workout.name}`);
           } else {
             // No GPS data for this activity
-            await adminDb.collection('workouts').doc(workout.id).update({ 
-              routeData: { noGPS: true } 
+            await workout.ref.update({
+              routeData: { noGPS: true }
             });
             console.log(`⚠️ No GPS: ${workout.name}`);
           }
@@ -175,7 +175,7 @@ export async function POST(request: NextRequest) {
 
     // Count remaining (exclude processed ones)
     const remainingSnapshot = await adminDb
-      .collection('workouts')
+      .collectionGroup('workouts')
       .where('source', '==', 'strava')
       .limit(500)
       .get();

--- a/src/app/api/strava/migrate-routes/status/route.ts
+++ b/src/app/api/strava/migrate-routes/status/route.ts
@@ -5,9 +5,9 @@ import { adminDb } from '@/lib/firebase/admin';
 
 export async function GET() {
   try {
-    // Get all Strava workouts
+    // Get all Strava workouts across all user subcollections
     const workoutsSnapshot = await adminDb
-      .collection('workouts')
+      .collectionGroup('workouts')
       .where('source', '==', 'strava')
       .get();
 

--- a/src/app/api/strava/sync/route.ts
+++ b/src/app/api/strava/sync/route.ts
@@ -212,8 +212,7 @@ async function findMatchingWorkout(
   // Query for workouts assigned to this user, same type, same day
   // that are NOT from Strava and NOT completed
   const workoutsSnapshot = await adminDb
-    .collection('workouts')
-    .where('assignedTo', '==', userId)
+    .collection('users').doc(userId).collection('workouts')
     .where('type', '==', workoutType)
     .where('completed', '==', false)
     .get();
@@ -250,8 +249,7 @@ async function findDuplicatesByName(
 
     // Query for workouts assigned to this user with the same type
     const workoutsSnapshot = await adminDb
-      .collection('workouts')
-      .where('assignedTo', '==', userId)
+      .collection('users').doc(userId).collection('workouts')
       .where('type', '==', workoutType)
       .get();
 
@@ -436,8 +434,7 @@ export async function GET(request: NextRequest) {
 
     // Get existing Strava workout IDs to avoid duplicates
     const existingWorkoutsSnapshot = await adminDb
-      .collection('workouts')
-      .where('assignedTo', '==', userId)
+      .collection('users').doc(userId).collection('workouts')
       .where('source', '==', 'strava')
       .get();
 
@@ -551,7 +548,7 @@ export async function GET(request: NextRequest) {
 
       // Double-check this activity doesn't already exist (real-time check)
       const existingCheck = await adminDb
-        .collection('workouts')
+        .collection('users').doc(userId).collection('workouts')
         .where('stravaActivityId', '==', stravaId)
         .limit(1)
         .get();
@@ -592,7 +589,7 @@ export async function GET(request: NextRequest) {
         // User chose to merge with existing workout
         console.log(`  🔗 Merging: ${activity.name}`);
 
-        await adminDb.collection('workouts').doc(decision.workoutId).update({
+        await adminDb.collection('users').doc(userId).collection('workouts').doc(decision.workoutId).update({
           completed: true,
           completedAt: admin.firestore.Timestamp.fromDate(activityDate),
           completedBy: 'strava',
@@ -609,7 +606,7 @@ export async function GET(request: NextRequest) {
           // Auto-merge with date-matched workout
           console.log(`  🔗 Auto-merge: ${activity.name} → ${matchingWorkout.data.name}`);
 
-          await adminDb.collection('workouts').doc(matchingWorkout.id).update({
+          await adminDb.collection('users').doc(userId).collection('workouts').doc(matchingWorkout.id).update({
             completed: true,
             completedAt: admin.firestore.Timestamp.fromDate(activityDate),
             completedBy: 'strava',
@@ -623,8 +620,7 @@ export async function GET(request: NextRequest) {
           const thirtyMinBefore = new Date(activityDate.getTime() - 30 * 60 * 1000);
           const thirtyMinAfter = new Date(activityDate.getTime() + 30 * 60 * 1000);
           const proximitySnap = await adminDb
-            .collection('workouts')
-            .where('assignedTo', '==', userId)
+            .collection('users').doc(userId).collection('workouts')
             .where('type', '==', workoutType)
             .where('source', '==', 'strava')
             .where('date', '>=', admin.firestore.Timestamp.fromDate(thirtyMinBefore))
@@ -662,6 +658,7 @@ export async function GET(request: NextRequest) {
             description: `Imported from Strava\nDistance: ${((activity.distance || 0) / 1000).toFixed(2)} km\nMoving time: ${Math.round((activity.moving_time || 0) / 60)} min`,
             date: admin.firestore.Timestamp.fromDate(activityDate),
             duration: Math.round((activity.moving_time || 0) / 60),
+            ownerUsername: userId,
             createdBy: userId,
             assignedTo: userId,
             completed: true,
@@ -723,7 +720,7 @@ export async function GET(request: NextRequest) {
             };
           }
 
-          await adminDb.collection('workouts').doc(`strava_${stravaId}`).set(newWorkoutData);
+          await adminDb.collection('users').doc(userId).collection('workouts').doc(`strava_${stravaId}`).set(newWorkoutData);
           newWorkoutsCount++;
           }
         }
@@ -748,7 +745,7 @@ export async function GET(request: NextRequest) {
       const { result: dedupResult } = await runDedupPipeline(userId);
       if (dedupResult.duplicatesFound > 0) {
         console.log(`🗑️ Groq found ${dedupResult.duplicatesFound} duplicates — auto-deleting`);
-        const deleted = await executeDedupDeletions(dedupResult);
+        const deleted = await executeDedupDeletions(dedupResult, userId);
         console.log(`✅ Deleted ${deleted} duplicate workouts`);
         dedupInfo = { duplicatesRemoved: deleted, model: dedupResult.model };
       } else {

--- a/src/app/api/strava/test-match/route.ts
+++ b/src/app/api/strava/test-match/route.ts
@@ -31,7 +31,7 @@ function mapStravaType(stravaType: string): 'swim' | 'run' | 'bike' | 'strength'
   return typeMap[stravaType] || 'strength';
 }
 
-async function refreshStravaToken(userId: string, refreshToken: string): Promise<string | null> {
+async function refreshStravaToken(username: string, refreshToken: string): Promise<string | null> {
   try {
     const response = await fetch('https://www.strava.com/oauth/token', {
       method: 'POST',
@@ -48,7 +48,7 @@ async function refreshStravaToken(userId: string, refreshToken: string): Promise
 
     const data = await response.json();
 
-    await adminDb.collection('users').doc(userId).update({
+    await adminDb.collection('users').doc(username).update({
       stravaAccessToken: data.access_token,
       stravaRefreshToken: data.refresh_token,
       stravaTokenExpiresAt: data.expires_at,
@@ -62,12 +62,12 @@ async function refreshStravaToken(userId: string, refreshToken: string): Promise
   }
 }
 
-async function getAccessToken(userId: string, userData: any): Promise<string | null> {
+async function getAccessToken(username: string, userData: any): Promise<string | null> {
   let accessToken = userData.stravaAccessToken;
   const currentTime = Math.floor(Date.now() / 1000);
 
   if (userData.stravaTokenExpiresAt && userData.stravaTokenExpiresAt < currentTime) {
-    const newToken = await refreshStravaToken(userId, userData.stravaRefreshToken);
+    const newToken = await refreshStravaToken(username, userData.stravaRefreshToken);
     if (!newToken) return null;
     accessToken = newToken;
   }
@@ -76,7 +76,7 @@ async function getAccessToken(userId: string, userData: any): Promise<string | n
 }
 
 async function findMatchingWorkout(
-  userId: string,
+  username: string,
   activityDate: Date,
   activityType: 'swim' | 'run' | 'bike' | 'strength',
   stravaActivityId: string
@@ -87,9 +87,9 @@ async function findMatchingWorkout(
   const endOfDay = new Date(activityDate);
   endOfDay.setHours(23, 59, 59, 999);
 
-  // Check if already linked
+  // Check if already linked (search across all user subcollections)
   const existingLinkSnapshot = await adminDb
-    .collection('workouts')
+    .collectionGroup('workouts')
     .where('stravaActivityId', '==', stravaActivityId)
     .limit(1)
     .get();
@@ -98,10 +98,9 @@ async function findMatchingWorkout(
     return { alreadyLinked: true, workoutId: existingLinkSnapshot.docs[0].id };
   }
 
-  // Find uncompleted workouts for this day
+  // Find uncompleted workouts for this day in user's subcollection
   const workoutsSnapshot = await adminDb
-    .collection('workouts')
-    .where('assignedTo', '==', userId)
+    .collection('users').doc(username).collection('workouts')
     .where('date', '>=', admin.firestore.Timestamp.fromDate(startOfDay))
     .where('date', '<=', admin.firestore.Timestamp.fromDate(endOfDay))
     .where('completed', '==', false)
@@ -132,15 +131,15 @@ async function findMatchingWorkout(
 export async function GET(request: NextRequest) {
   try {
     const { searchParams } = new URL(request.url);
-    const userId = searchParams.get('userId');
+    const username = searchParams.get('userId'); // param name kept for backward compat, value is now username
     const activityId = searchParams.get('activityId');
 
-    if (!userId) {
+    if (!username) {
       return NextResponse.json({ error: 'userId required' }, { status: 400 });
     }
 
-    // Get user data
-    const userDoc = await adminDb.collection('users').doc(userId).get();
+    // Get user data (doc.id is now username)
+    const userDoc = await adminDb.collection('users').doc(username).get();
     if (!userDoc.exists) {
       return NextResponse.json({ error: 'User not found' }, { status: 404 });
     }
@@ -152,7 +151,7 @@ export async function GET(request: NextRequest) {
     }
 
     // Get access token
-    const accessToken = await getAccessToken(userId, userData);
+    const accessToken = await getAccessToken(username, userData);
     if (!accessToken) {
       return NextResponse.json({ error: 'Failed to get access token' }, { status: 401 });
     }
@@ -197,7 +196,7 @@ export async function GET(request: NextRequest) {
     const activityDate = new Date(activity.start_date_local);
 
     // Find matching workout
-    const match = await findMatchingWorkout(userId, activityDate, workoutType, String(activity.id));
+    const match = await findMatchingWorkout(username, activityDate, workoutType, String(activity.id));
 
     return NextResponse.json({
       activity: {
@@ -230,14 +229,14 @@ export async function GET(request: NextRequest) {
 export async function POST(request: NextRequest) {
   try {
     const body = await request.json();
-    const { userId, activityId, dryRun = false } = body;
+    const { userId: username, activityId, dryRun = false } = body; // userId value is now username
 
-    if (!userId) {
+    if (!username) {
       return NextResponse.json({ error: 'userId required' }, { status: 400 });
     }
 
-    // Get user data
-    const userDoc = await adminDb.collection('users').doc(userId).get();
+    // Get user data (doc.id is now username)
+    const userDoc = await adminDb.collection('users').doc(username).get();
     if (!userDoc.exists) {
       return NextResponse.json({ error: 'User not found' }, { status: 404 });
     }
@@ -248,7 +247,7 @@ export async function POST(request: NextRequest) {
     }
 
     // Get access token
-    const accessToken = await getAccessToken(userId, userData);
+    const accessToken = await getAccessToken(username, userData);
     if (!accessToken) {
       return NextResponse.json({ error: 'Failed to get access token' }, { status: 401 });
     }
@@ -286,7 +285,7 @@ export async function POST(request: NextRequest) {
     const activityDate = new Date(activity.start_date_local);
 
     // Find matching workout
-    const match = await findMatchingWorkout(userId, activityDate, workoutType, String(activity.id));
+    const match = await findMatchingWorkout(username, activityDate, workoutType, String(activity.id));
 
     if (match.alreadyLinked || match.noWorkouts || match.noMatch) {
       return NextResponse.json({
@@ -316,7 +315,7 @@ export async function POST(request: NextRequest) {
     if (activity.max_speed) actualStats.maxSpeed = activity.max_speed;
     if (activity.total_elevation_gain) actualStats.elevationGain = activity.total_elevation_gain;
 
-    await adminDb.collection('workouts').doc(match.workoutId).update({
+    await adminDb.collection('users').doc(username).collection('workouts').doc(match.workoutId).update({
       completed: true,
       completedAt: admin.firestore.FieldValue.serverTimestamp(),
       completionStatus: 'completed',

--- a/src/app/api/templates/route.ts
+++ b/src/app/api/templates/route.ts
@@ -2,6 +2,7 @@ export const dynamic = 'force-dynamic';
 
 import { NextRequest, NextResponse } from 'next/server';
 import { adminDb } from '@/lib/firebase/admin';
+import { adminResolveUsername } from '@/lib/firebase/adminUserMapping';
 
 // GET: List all templates for a user
 export async function GET(request: NextRequest) {
@@ -60,8 +61,8 @@ export async function POST(request: NextRequest) {
     const docRef = await adminDb.collection('workoutTemplates').add(templateData);
 
     // If workoutId is provided, update the workout to track the templateId
-    if (workoutId) {
-      await adminDb.collection('workouts').doc(workoutId).update({
+    if (workoutId && createdBy) {
+      await adminDb.collection('users').doc(createdBy).collection('workouts').doc(workoutId).update({
         templateId: docRef.id,
         updatedAt: new Date(),
       });
@@ -101,8 +102,8 @@ export async function DELETE(request: NextRequest) {
     }
 
     // If template has a workoutId, remove the templateId from that workout
-    if (templateData?.workoutId) {
-      await adminDb.collection('workouts').doc(templateData.workoutId).update({
+    if (templateData?.workoutId && templateData?.createdBy) {
+      await adminDb.collection('users').doc(templateData.createdBy).collection('workouts').doc(templateData.workoutId).update({
         templateId: null,
         updatedAt: new Date(),
       });

--- a/src/app/api/test/strava-sim/route.ts
+++ b/src/app/api/test/strava-sim/route.ts
@@ -114,18 +114,18 @@ function generateMockActivities() {
 
 // GET: Run dedup on existing real user data (dry-run)
 export async function GET(request: NextRequest) {
-  const userId = request.nextUrl.searchParams.get('userId');
-  if (!userId) {
+  const username = request.nextUrl.searchParams.get('userId'); // param name kept for compat, value is now username
+  if (!username) {
     return NextResponse.json({ error: 'userId query param required' }, { status: 400 });
   }
 
   try {
-    const { workouts, result } = await runDedupPipeline(userId);
+    const { workouts, result } = await runDedupPipeline(username);
 
     return NextResponse.json({
       success: true,
       mode: 'dry-run (GET — no deletions)',
-      userId,
+      userId: username,
       totalWorkouts: workouts.length,
       workoutsSent: workouts.map(w => ({
         id: w.id, name: w.name, type: w.type, date: w.date,
@@ -141,10 +141,10 @@ export async function GET(request: NextRequest) {
 
 // POST: Full simulation — create mock data → run dedup → optionally delete
 export async function POST(request: NextRequest) {
-  const userId = request.nextUrl.searchParams.get('userId');
+  const username = request.nextUrl.searchParams.get('userId'); // param name kept for compat, value is now username
   const execute = request.nextUrl.searchParams.get('execute') === 'true';
 
-  if (!userId) {
+  if (!username) {
     return NextResponse.json({ error: 'userId query param required' }, { status: 400 });
   }
 
@@ -153,7 +153,7 @@ export async function POST(request: NextRequest) {
 
   try {
     // ── Step 1: Verify user exists ──
-    const userDoc = await adminDb.collection('users').doc(userId).get();
+    const userDoc = await adminDb.collection('users').doc(username).get();
     if (!userDoc.exists) {
       return NextResponse.json({ error: 'User not found' }, { status: 404 });
     }
@@ -167,7 +167,7 @@ export async function POST(request: NextRequest) {
     for (const activity of mockActivities) {
       const docId = `test_${activity.id}`;
       mockIds.push(docId);
-      const ref = adminDb.collection('workouts').doc(docId);
+      const ref = adminDb.collection('users').doc(username).collection('workouts').doc(docId);
       batch.set(ref, {
         name: activity.name,
         type: activity.type,
@@ -179,8 +179,9 @@ export async function POST(request: NextRequest) {
         },
         source: activity.source,
         stravaActivityId: activity.stravaActivityId || null,
-        assignedTo: userId,
-        createdBy: userId,
+        ownerUsername: username,
+        assignedTo: username,
+        createdBy: username,
         completed: true,
         createdAt: admin.firestore.FieldValue.serverTimestamp(),
         updatedAt: admin.firestore.FieldValue.serverTimestamp(),
@@ -191,7 +192,7 @@ export async function POST(request: NextRequest) {
 
     // ── Step 3: Run Groq dedup pipeline on ALL user workouts ──
     timeline.push('🔍 Running Groq dedup pipeline...');
-    const { workouts, result } = await runDedupPipeline(userId);
+    const { workouts, result } = await runDedupPipeline(username);
     timeline.push(`📊 Analyzed ${workouts.length} total workouts`);
     timeline.push(`🎯 Groq found ${result.duplicatesFound} duplicates (model: ${result.model})`);
 
@@ -204,7 +205,7 @@ export async function POST(request: NextRequest) {
     // ── Step 4: Execute or dry-run ──
     let deletedCount = 0;
     if (execute && result.deletions.length > 0) {
-      deletedCount = await executeDedupDeletions(result);
+      deletedCount = await executeDedupDeletions(result, username);
       timeline.push(`✅ EXECUTED: Deleted ${deletedCount} duplicate workouts`);
     } else if (result.deletions.length > 0) {
       timeline.push(`⏸️ DRY-RUN: Would delete ${result.deletions.length} workouts. Use ?execute=true to delete.`);
@@ -214,7 +215,7 @@ export async function POST(request: NextRequest) {
     const cleanupBatch = adminDb.batch();
     let cleanedUp = 0;
     for (const docId of mockIds) {
-      const docRef = adminDb.collection('workouts').doc(docId);
+      const docRef = adminDb.collection('users').doc(username).collection('workouts').doc(docId);
       const docSnap = await docRef.get();
       if (docSnap.exists) {
         cleanupBatch.delete(docRef);
@@ -229,7 +230,7 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({
       success: true,
       mode: execute ? 'EXECUTE' : 'DRY-RUN',
-      userId,
+      userId: username,
       timeline,
       simulation: {
         mockActivitiesCreated: mockActivities.length,
@@ -249,7 +250,7 @@ export async function POST(request: NextRequest) {
     try {
       const cleanupBatch = adminDb.batch();
       for (const docId of mockIds) {
-        cleanupBatch.delete(adminDb.collection('workouts').doc(docId));
+        cleanupBatch.delete(adminDb.collection('users').doc(username).collection('workouts').doc(docId));
       }
       await cleanupBatch.commit();
     } catch { /* ignore cleanup errors */ }

--- a/src/app/api/webhooks/strava/route.ts
+++ b/src/app/api/webhooks/strava/route.ts
@@ -147,14 +147,14 @@ async function processActivity(
     }
 
     const userDoc = usersSnapshot.docs[0];
-    const userId = userDoc.id;
+    const username = userDoc.id;
     const userData = userDoc.data();
 
-    console.log(`👤 Found user: ${userData.displayName} (${userId})`);
+    console.log(`👤 Found user: ${userData.displayName} (${username})`);
 
     // Check if we already imported this activity (STRICT CHECK)
     const existingWorkout = await adminDb
-      .collection('workouts')
+      .collection('users').doc(username).collection('workouts')
       .where('stravaActivityId', '==', stravaActivityId)
       .limit(1)
       .get();
@@ -166,7 +166,7 @@ async function processActivity(
 
     // DOUBLE CHECK: Also check by activity ID string conversion
     const existingWorkout2 = await adminDb
-      .collection('workouts')
+      .collection('users').doc(username).collection('workouts')
       .where('stravaActivityId', '==', String(stravaActivityId))
       .limit(1)
       .get();
@@ -180,8 +180,7 @@ async function processActivity(
     // This catches rapid duplicate webhooks
     const sixtySecondsAgo = new Date(Date.now() - 60000);
     const recentWorkouts = await adminDb
-      .collection('workouts')
-      .where('assignedTo', '==', userId)
+      .collection('users').doc(username).collection('workouts')
       .where('source', '==', 'strava')
       .where('createdAt', '>', admin.firestore.Timestamp.fromDate(sixtySecondsAgo))
       .get();
@@ -191,7 +190,7 @@ async function processActivity(
     }
 
     // Get access token
-    const accessToken = await getAccessToken(userId, userData);
+    const accessToken = await getAccessToken(username, userData);
     if (!accessToken) {
       return { success: false, message: 'Failed to get access token' };
     }
@@ -214,8 +213,7 @@ async function processActivity(
     const thirtyMinAfter = new Date(activityDate.getTime() + 30 * 60 * 1000);
     
     const proximityCheck = await adminDb
-      .collection('workouts')
-      .where('assignedTo', '==', userId)
+      .collection('users').doc(username).collection('workouts')
       .where('type', '==', workoutType)
       .where('source', '==', 'strava')
       .where('date', '>=', admin.firestore.Timestamp.fromDate(thirtyMinBefore))
@@ -261,16 +259,17 @@ async function processActivity(
     // CREATE NEW WORKOUT from Strava activity
     // Use deterministic doc ID to prevent duplicates from concurrent webhook retries
     const workoutId = `strava_${stravaActivityId}`;
-    const newWorkoutRef = adminDb.collection('workouts').doc(workoutId);
-    
+    const newWorkoutRef = adminDb.collection('users').doc(username).collection('workouts').doc(workoutId);
+
     const newWorkoutData: any = {
       name: activity.name,
       type: workoutType,
       description: `Imported from Strava\nDistance: ${((activity.distance || 0) / 1000).toFixed(2)} km\nMoving time: ${Math.round((activity.moving_time || 0) / 60)} min`,
       date: admin.firestore.Timestamp.fromDate(activityDate),
       duration: Math.round((activity.moving_time || 0) / 60),
-      createdBy: userId,
-      assignedTo: userId,
+      ownerUsername: username,
+      createdBy: username,
+      assignedTo: username,
       completed: true,
       completedAt: admin.firestore.Timestamp.fromDate(activityDate),
       completedBy: 'strava',
@@ -328,8 +327,7 @@ async function processActivity(
     twoDaysAfter.setDate(twoDaysAfter.getDate() + 2);
 
     const oldWorkoutsSnapshot = await adminDb
-      .collection('workouts')
-      .where('assignedTo', '==', userId)
+      .collection('users').doc(username).collection('workouts')
       .where('type', '==', workoutType)
       .where('completed', '==', false)
       .where('date', '>=', admin.firestore.Timestamp.fromDate(twoDaysBefore))
@@ -417,12 +415,12 @@ export async function POST(request: NextRequest) {
               const userSnap = await adminDb.collection('users')
                 .where('stravaId', '==', String(owner_id)).limit(1).get();
               if (!userSnap.empty) {
-                const userId = userSnap.docs[0].id;
-                console.log('🔍 Running Groq dedup for user:', userId);
-                const { result: dedupResult } = await runDedupPipeline(userId);
+                const username = userSnap.docs[0].id;
+                console.log('🔍 Running Groq dedup for user:', username);
+                const { result: dedupResult } = await runDedupPipeline(username);
                 if (dedupResult.duplicatesFound > 0) {
                   console.log(`🗑️ Groq found ${dedupResult.duplicatesFound} duplicates — deleting`);
-                  const deleted = await executeDedupDeletions(dedupResult);
+                  const deleted = await executeDedupDeletions(dedupResult, username);
                   console.log(`✅ Deleted ${deleted} duplicate workouts`);
                 } else {
                   console.log('✅ No duplicates found');

--- a/src/app/api/workouts/[id]/route.ts
+++ b/src/app/api/workouts/[id]/route.ts
@@ -3,8 +3,10 @@ export const dynamic = 'force-dynamic';
 import { NextRequest, NextResponse } from 'next/server';
 
 /**
- * GET /api/workouts/[id]
+ * GET /api/workouts/[id]?ownerUsername=xxx
  * Fetch a single workout by ID
+ * Requires ownerUsername query param to construct subcollection path:
+ *   users/{ownerUsername}/workouts/{id}
  */
 export async function GET(
   request: NextRequest,
@@ -12,12 +14,16 @@ export async function GET(
 ) {
   try {
     const { id } = await params;
-    
-    // In production, fetch from Firestore here
+    const { searchParams } = new URL(request.url);
+    const ownerUsername = searchParams.get('ownerUsername');
+
+    // In production, fetch from Firestore here:
+    //   adminDb.collection('users').doc(ownerUsername).collection('workouts').doc(id)
     // For this app, we use client-side Firestore queries
     return NextResponse.json({
       message: 'Use client-side Firestore queries',
-      id
+      id,
+      ownerUsername,
     });
   } catch (error: any) {
     return NextResponse.json(
@@ -28,8 +34,10 @@ export async function GET(
 }
 
 /**
- * PUT /api/workouts/[id]
+ * PUT /api/workouts/[id]?ownerUsername=xxx
  * Update a workout
+ * Requires ownerUsername query param to construct subcollection path:
+ *   users/{ownerUsername}/workouts/{id}
  */
 export async function PUT(
   request: NextRequest,
@@ -37,13 +45,17 @@ export async function PUT(
 ) {
   try {
     const { id } = await params;
+    const { searchParams } = new URL(request.url);
+    const ownerUsername = searchParams.get('ownerUsername');
     const body = await request.json();
-    
-    // In production, update in Firestore here
+
+    // In production, update in Firestore here:
+    //   adminDb.collection('users').doc(ownerUsername).collection('workouts').doc(id)
     // For this app, we use client-side Firestore operations
     return NextResponse.json({
       message: 'Use client-side Firestore operations',
       id,
+      ownerUsername,
       success: true
     });
   } catch (error: any) {
@@ -55,8 +67,10 @@ export async function PUT(
 }
 
 /**
- * DELETE /api/workouts/[id]
+ * DELETE /api/workouts/[id]?ownerUsername=xxx
  * Delete a workout
+ * Requires ownerUsername query param to construct subcollection path:
+ *   users/{ownerUsername}/workouts/{id}
  */
 export async function DELETE(
   request: NextRequest,
@@ -64,12 +78,16 @@ export async function DELETE(
 ) {
   try {
     const { id } = await params;
-    
-    // In production, delete from Firestore here
+    const { searchParams } = new URL(request.url);
+    const ownerUsername = searchParams.get('ownerUsername');
+
+    // In production, delete from Firestore here:
+    //   adminDb.collection('users').doc(ownerUsername).collection('workouts').doc(id)
     // For this app, we use client-side Firestore operations
     return NextResponse.json({
       message: 'Use client-side Firestore operations',
       id,
+      ownerUsername,
       success: true
     });
   } catch (error: any) {

--- a/src/app/api/workouts/auto-dedup/route.ts
+++ b/src/app/api/workouts/auto-dedup/route.ts
@@ -7,6 +7,7 @@ interface WorkoutDoc {
   name: string;
   type: string;
   assignedTo: string;
+  ownerUsername: string;
   source?: string;
   date: any;
   duration?: number;
@@ -168,13 +169,14 @@ export async function POST(request: NextRequest) {
     const { userId } = await request.json();
     if (!userId) return NextResponse.json({ error: 'userId required' }, { status: 400 });
 
-    // Fetch all workouts for this user
-    const snapshot = await adminDb.collection('workouts')
-      .where('assignedTo', '==', userId)
+    // userId is now a username — fetch workouts from user's subcollection
+    const snapshot = await adminDb
+      .collection('users').doc(userId).collection('workouts')
       .get();
 
     const workouts: WorkoutDoc[] = snapshot.docs.map(doc => ({
       id: doc.id,
+      ownerUsername: userId,
       ...doc.data(),
     } as WorkoutDoc));
 
@@ -185,12 +187,13 @@ export async function POST(request: NextRequest) {
     const userData = userDoc.data();
     if (userData?.role === 'coach') {
       const studentsSnap = await adminDb.collection('users')
-        .where('coachId', '==', userId).get();
+        .where('coachUsername', '==', userId).get();
       for (const student of studentsSnap.docs) {
-        const studentWorkouts = await adminDb.collection('workouts')
-          .where('assignedTo', '==', student.id).get();
+        const studentWorkouts = await adminDb
+          .collection('users').doc(student.id).collection('workouts')
+          .get();
         studentWorkouts.docs.forEach(doc => {
-          workouts.push({ id: doc.id, ...doc.data() } as WorkoutDoc);
+          workouts.push({ id: doc.id, ownerUsername: student.id, ...doc.data() } as WorkoutDoc);
         });
       }
     }
@@ -209,7 +212,9 @@ export async function POST(request: NextRequest) {
 
     for (const group of dupGroups) {
       for (const dup of group.delete) {
-        batch.delete(adminDb.collection('workouts').doc(dup.id));
+        batch.delete(
+          adminDb.collection('users').doc(dup.ownerUsername).collection('workouts').doc(dup.id)
+        );
         deletedIds.push(dup.id);
       }
       groupSummaries.push(

--- a/src/app/api/workouts/route.ts
+++ b/src/app/api/workouts/route.ts
@@ -75,13 +75,13 @@ function toEpochMs(dateValue: unknown): number {
   return 0;
 }
 
-async function getCoachStudentIds(coachId: string): Promise<string[]> {
+async function getCoachStudentUsernames(coachUsername: string): Promise<string[]> {
   const studentsSnapshot = await adminDb
     .collection('users')
-    .where('coachId', '==', coachId)
+    .where('coachUsername', '==', coachUsername)
     .get();
 
-  return studentsSnapshot.docs.map((doc) => doc.id);
+  return studentsSnapshot.docs.map((doc) => doc.id); // doc.id is username
 }
 
 function normalizeTagList(tags: unknown): string[] {
@@ -116,20 +116,20 @@ export async function GET(request: NextRequest) {
     const workoutsById = new Map<string, Record<string, unknown>>();
 
     if (role === 'coach') {
-      const [coachCreatedSnapshot, studentIds] = await Promise.all([
-        adminDb.collection('workouts').where('createdBy', '==', userId).get(),
-        getCoachStudentIds(userId),
+      const [coachCreatedSnapshot, studentUsernames] = await Promise.all([
+        adminDb.collectionGroup('workouts').where('createdBy', '==', userId).get(),
+        getCoachStudentUsernames(userId),
       ]);
 
       coachCreatedSnapshot.docs.forEach((doc) => {
         workoutsById.set(doc.id, { id: doc.id, ...doc.data() });
       });
 
-      if (studentIds.length > 0) {
-        for (let i = 0; i < studentIds.length; i += 10) {
-          const batch = studentIds.slice(i, i + 10);
+      if (studentUsernames.length > 0) {
+        for (let i = 0; i < studentUsernames.length; i += 10) {
+          const batch = studentUsernames.slice(i, i + 10);
           const studentSnapshot = await adminDb
-            .collection('workouts')
+            .collectionGroup('workouts')
             .where('assignedTo', 'in', batch)
             .get();
 
@@ -141,10 +141,18 @@ export async function GET(request: NextRequest) {
           });
         }
       }
+
+      // Also query the coach's own subcollection for self-assigned workouts
+      const coachOwnSnapshot = await adminDb
+        .collection('users').doc(userId).collection('workouts')
+        .get();
+
+      coachOwnSnapshot.docs.forEach((doc) => {
+        workoutsById.set(doc.id, { id: doc.id, ...doc.data() });
+      });
     } else if (role === 'athlete' || role === 'student') {
       const athleteSnapshot = await adminDb
-        .collection('workouts')
-        .where('assignedTo', '==', userId)
+        .collection('users').doc(userId).collection('workouts')
         .get();
 
       athleteSnapshot.docs.forEach((doc) => {
@@ -152,8 +160,8 @@ export async function GET(request: NextRequest) {
       });
     } else {
       const [createdSnapshot, assignedSnapshot] = await Promise.all([
-        adminDb.collection('workouts').where('createdBy', '==', userId).get(),
-        adminDb.collection('workouts').where('assignedTo', '==', userId).get(),
+        adminDb.collectionGroup('workouts').where('createdBy', '==', userId).get(),
+        adminDb.collectionGroup('workouts').where('assignedTo', '==', userId).get(),
       ]);
 
       createdSnapshot.docs.forEach((doc) => {
@@ -211,6 +219,7 @@ export async function POST(_: NextRequest) {
       date: toTimestamp(body.date) ?? admin.firestore.Timestamp.fromDate(new Date()),
       createdBy,
       assignedTo,
+      ownerUsername: assignedTo,
       completed: false,
       source: typeof body.source === 'string' ? body.source : 'manual',
       createdAt: admin.firestore.FieldValue.serverTimestamp(),
@@ -237,7 +246,7 @@ export async function POST(_: NextRequest) {
       }
     });
 
-    const createdRef = await adminDb.collection('workouts').add(workoutData);
+    const createdRef = await adminDb.collection('users').doc(assignedTo).collection('workouts').add(workoutData);
     const createdDoc = await createdRef.get();
 
     return NextResponse.json({

--- a/src/app/preview/[username]/[id]/PreviewClient.tsx
+++ b/src/app/preview/[username]/[id]/PreviewClient.tsx
@@ -23,6 +23,7 @@ import Link from 'next/link';
 
 interface PreviewWorkout {
   id: string;
+  ownerUsername: string;
   name: string;
   type: string;
   description: string;
@@ -76,7 +77,11 @@ export function PreviewClient({ workout }: { workout: PreviewWorkout }) {
       const res = await fetch('/api/workouts/copy', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ workoutId: workout.id, userId: user.uid }),
+        body: JSON.stringify({
+          ownerUsername: workout.ownerUsername,
+          workoutId: workout.id,
+          userId: user.username,
+        }),
       });
       if (!res.ok) throw new Error('Failed to copy workout');
       toast.success('Workout added to your list!');

--- a/src/app/preview/[username]/[id]/page.tsx
+++ b/src/app/preview/[username]/[id]/page.tsx
@@ -4,13 +4,13 @@ import { notFound } from 'next/navigation';
 import { PreviewClient } from './PreviewClient';
 
 interface PreviewPageProps {
-  params: Promise<{ id: string }>;
+  params: Promise<{ username: string; id: string }>;
 }
 
-async function getWorkout(id: string) {
+async function getWorkout(username: string, id: string) {
   try {
     const db = getAdminDb();
-    const doc = await db.collection('workouts').doc(id).get();
+    const doc = await db.collection('users').doc(username).collection('workouts').doc(id).get();
     if (!doc.exists) return null;
 
     const data = doc.data()!;
@@ -26,6 +26,7 @@ async function getWorkout(id: string) {
 
     return {
       id: doc.id,
+      ownerUsername: username,
       name: data.name || 'Untitled Workout',
       type: data.type || 'other',
       description: data.description || '',
@@ -64,8 +65,8 @@ async function getWorkout(id: string) {
 }
 
 export async function generateMetadata({ params }: PreviewPageProps): Promise<Metadata> {
-  const { id } = await params;
-  const workout = await getWorkout(id);
+  const { username, id } = await params;
+  const workout = await getWorkout(username, id);
 
   if (!workout) {
     return { title: 'Workout Not Found | The Daily Athlete' };
@@ -97,8 +98,8 @@ export async function generateMetadata({ params }: PreviewPageProps): Promise<Me
 }
 
 export default async function PreviewPage({ params }: PreviewPageProps) {
-  const { id } = await params;
-  const workout = await getWorkout(id);
+  const { username, id } = await params;
+  const workout = await getWorkout(username, id);
 
   if (!workout) {
     notFound();

--- a/src/app/workout/[id]/page.tsx
+++ b/src/app/workout/[id]/page.tsx
@@ -1,98 +1,47 @@
-import { Metadata } from 'next';
 import { getAdminDb } from '@/lib/firebase/admin';
-import { WorkoutPreview } from '@/components/workouts/WorkoutPreview';
-import { notFound } from 'next/navigation';
+import { redirect, notFound } from 'next/navigation';
 
 interface WorkoutPageProps {
   params: Promise<{ id: string }>;
 }
 
-async function getWorkout(id: string) {
+/**
+ * Legacy /workout/[id] route -- redirects to /preview/[username]/[id].
+ * Scans the 'workouts' collectionGroup to locate the workout by document ID,
+ * then extracts the owner username from the document path.
+ *
+ * Note: This is a legacy compatibility route. New share URLs use the format
+ * /preview/[username]/[id] which allows direct document lookup.
+ */
+async function findWorkoutOwner(workoutId: string): Promise<string | null> {
   try {
     const db = getAdminDb();
-    const doc = await db.collection('workouts').doc(id).get();
-    if (!doc.exists) return null;
+    // Scan workouts collectionGroup to find the document by ID.
+    // This is acceptable for a legacy redirect route that will see minimal traffic.
+    const snapshot = await db.collectionGroup('workouts').select().get();
 
-    const data = doc.data()!;
-    return {
-      id: doc.id,
-      name: data.name || 'Untitled Workout',
-      type: data.type || 'other',
-      description: data.description || '',
-      date: data.date?.toDate?.()?.toISOString() || new Date().toISOString(),
-      duration: data.duration || null,
-      completed: data.completed || false,
-      source: data.source || 'manual',
-      run: data.run || null,
-      bike: data.bike || null,
-      swim: data.swim || null,
-      strength: data.strength || null,
-      other: data.other || null,
-      actualStats: data.actualStats
-        ? {
-            distance: data.actualStats.distance || null,
-            duration: data.actualStats.duration || null,
-            calories: data.actualStats.calories || null,
-            avgHeartRate: data.actualStats.avgHeartRate || null,
-          }
-        : null,
-      routeData: data.routeData
-        ? {
-            polyline: data.routeData.polyline || null,
-            startLatLng: data.routeData.startLatLng || null,
-          }
-        : null,
-      tags: data.tags || [],
-      photos: data.photos || [],
-    };
+    for (const doc of snapshot.docs) {
+      if (doc.id === workoutId) {
+        // Document path: users/{username}/workouts/{workoutId}
+        const segments = doc.ref.path.split('/');
+        return segments[1] || null;
+      }
+    }
+
+    return null;
   } catch (error) {
-    console.error('Error fetching workout for preview:', error);
+    console.error('Error finding workout owner:', error);
     return null;
   }
 }
 
-export async function generateMetadata({ params }: WorkoutPageProps): Promise<Metadata> {
-  const { id } = await params;
-  const workout = await getWorkout(id);
-
-  if (!workout) {
-    return { title: 'Workout Not Found | The Daily Athlete' };
-  }
-
-  const description = workout.description
-    ? workout.description.slice(0, 160)
-    : `${workout.type.charAt(0).toUpperCase() + workout.type.slice(1)} workout on The Daily Athlete`;
-
-  return {
-    title: `${workout.name} | The Daily Athlete`,
-    description,
-    openGraph: {
-      title: workout.name,
-      description,
-      type: 'article',
-      siteName: 'The Daily Athlete',
-    },
-    twitter: {
-      card: 'summary',
-      title: workout.name,
-      description,
-    },
-  };
-}
-
 export default async function PublicWorkoutPage({ params }: WorkoutPageProps) {
   const { id } = await params;
-  const workout = await getWorkout(id);
+  const ownerUsername = await findWorkoutOwner(id);
 
-  if (!workout) {
+  if (!ownerUsername) {
     notFound();
   }
 
-  return (
-    <div className="min-h-screen bg-background">
-      <div className="container mx-auto px-4 py-8 max-w-3xl">
-        <WorkoutPreview workout={workout} workoutId={id} />
-      </div>
-    </div>
-  );
+  redirect(`/preview/${ownerUsername}/${id}`);
 }

--- a/src/components/auth/RegisterForm.tsx
+++ b/src/components/auth/RegisterForm.tsx
@@ -1,13 +1,15 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useCallback } from 'react';
 import { useRouter } from 'next/navigation';
 import { createUser, signInWithGoogle } from '@/lib/firebase/auth';
+import { validateUsername, isUsernameAvailable } from '@/lib/firebase/userMapping';
+import { useAuthStore } from '@/lib/stores/authStore';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { toast } from 'sonner';
-import { Dumbbell, Loader2, User, Mail, Lock, ArrowRight, AlertCircle } from 'lucide-react';
+import { Dumbbell, Loader2, User, Mail, Lock, ArrowRight, AlertCircle, AtSign } from 'lucide-react';
 import Link from 'next/link';
 
 export function RegisterForm() {
@@ -15,18 +17,28 @@ export function RegisterForm() {
     email: '',
     password: '',
     displayName: '',
+    username: '',
   });
   const [loading, setLoading] = useState(false);
   const [googleLoading, setGoogleLoading] = useState(false);
   const [nameError, setNameError] = useState('');
+  const [usernameError, setUsernameError] = useState('');
+  const [usernameChecking, setUsernameChecking] = useState(false);
   const router = useRouter();
+  const setNeedsUsername = useAuthStore((s) => s.setNeedsUsername);
 
   const handleGoogleSignUp = async () => {
     setGoogleLoading(true);
     try {
-      await signInWithGoogle();
-      toast.success('Account created!');
-      router.push('/onboarding');
+      const result = await signInWithGoogle();
+      if (result.type === 'existing') {
+        toast.success('Welcome back!');
+        router.push('/dashboard');
+      } else {
+        // New Google user needs to pick a username
+        setNeedsUsername(true, result);
+        router.push('/choose-username');
+      }
     } catch (error: any) {
       if (error.message !== 'Sign-in cancelled') {
         toast.error(error.message);
@@ -49,19 +61,54 @@ export function RegisterForm() {
       }
       return true;
     } catch {
-      // Allow through if check fails
       return true;
     }
   };
 
+  const handleUsernameChange = useCallback(async (value: string) => {
+    const lower = value.toLowerCase().replace(/[^a-z0-9_]/g, '');
+    setFormData((prev) => ({ ...prev, username: lower }));
+    setUsernameError('');
+
+    if (!lower) return;
+
+    const validation = validateUsername(lower);
+    if (!validation.valid) {
+      setUsernameError(validation.error || '');
+      return;
+    }
+
+    setUsernameChecking(true);
+    const available = await isUsernameAvailable(lower);
+    setUsernameChecking(false);
+    if (!available) {
+      setUsernameError('Username is already taken');
+    }
+  }, []);
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setNameError('');
+    setUsernameError('');
     setLoading(true);
 
     const trimmedName = formData.displayName.trim();
     if (trimmedName.length < 2) {
       setNameError('Name must be at least 2 characters.');
+      setLoading(false);
+      return;
+    }
+
+    const validation = validateUsername(formData.username);
+    if (!validation.valid) {
+      setUsernameError(validation.error || '');
+      setLoading(false);
+      return;
+    }
+
+    const available = await isUsernameAvailable(formData.username);
+    if (!available) {
+      setUsernameError('Username is already taken');
       setLoading(false);
       return;
     }
@@ -77,6 +124,7 @@ export function RegisterForm() {
         formData.email,
         formData.password,
         trimmedName,
+        formData.username,
         'athlete'
       );
 
@@ -113,6 +161,22 @@ export function RegisterForm() {
                 <span>{nameError}</span>
               </div>
             )}
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="username" className="text-sm font-medium text-white/70">Username</Label>
+            <div className="relative">
+              <AtSign className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-white/30" />
+              <Input id="username" type="text" placeholder="johndoe" value={formData.username} onChange={(e) => handleUsernameChange(e.target.value)} required maxLength={20} className={`pl-10 h-11 bg-white/5 border-white/10 text-white placeholder:text-white/25 focus:border-red-500 focus:ring-red-500/20 transition-colors ${usernameError ? 'border-red-500' : ''}`} />
+              {usernameChecking && <Loader2 className="absolute right-3 top-1/2 -translate-y-1/2 w-4 h-4 text-white/30 animate-spin" />}
+            </div>
+            {usernameError && (
+              <div className="flex items-center gap-1.5 text-red-400 text-sm animate-in fade-in slide-in-from-top-1 duration-200">
+                <AlertCircle className="w-3.5 h-3.5 shrink-0" />
+                <span>{usernameError}</span>
+              </div>
+            )}
+            <p className="text-xs text-white/25">Lowercase letters, numbers, underscores. 3-20 characters.</p>
           </div>
 
           <div className="space-y-2">

--- a/src/components/reports/dashboard/DuplicateRemover.tsx
+++ b/src/components/reports/dashboard/DuplicateRemover.tsx
@@ -27,10 +27,10 @@ export function DuplicateRemover({ workouts, onWorkoutsChanged }: DuplicateRemov
   const groups = detectDuplicates(workouts);
   const visibleGroups = groups.filter((_, i) => !dismissed.has(i));
 
-  const handleDelete = async (workoutId: string) => {
+  const handleDelete = async (ownerUsername: string, workoutId: string) => {
     setDeleting(prev => new Set(prev).add(workoutId));
     try {
-      await deleteWorkout(workoutId);
+      await deleteWorkout(ownerUsername, workoutId);
       toast.success('Duplicate workout removed');
       onWorkoutsChanged();
     } catch (err: any) {
@@ -51,7 +51,7 @@ export function DuplicateRemover({ workouts, onWorkoutsChanged }: DuplicateRemov
       setDeleting(prev => new Set(prev).add(w.id));
     }
     try {
-      await Promise.all(toDelete.map(w => deleteWorkout(w.id)));
+      await Promise.all(toDelete.map(w => deleteWorkout(w.ownerUsername, w.id)));
       toast.success(`Removed ${toDelete.length} duplicate(s)`);
       onWorkoutsChanged();
     } catch (err: any) {
@@ -173,7 +173,7 @@ export function DuplicateRemover({ workouts, onWorkoutsChanged }: DuplicateRemov
                       <Button
                         variant="ghost"
                         size="sm"
-                        onClick={() => handleDelete(w.id)}
+                        onClick={() => handleDelete(w.ownerUsername, w.id)}
                         disabled={deleting.has(w.id)}
                         className="text-red-500 hover:text-red-600 hover:bg-red-500/10 shrink-0"
                       >

--- a/src/components/workouts/ShareWorkoutCard.tsx
+++ b/src/components/workouts/ShareWorkoutCard.tsx
@@ -218,7 +218,7 @@ export function ShareWorkoutCard({ workout }: ShareWorkoutCardProps) {
   })();
 
   const aiComment = workout.routeData?.aiComment;
-  const shareUrl = typeof window !== 'undefined' ? `${window.location.origin}/preview/${workout.id}` : '';
+  const shareUrl = typeof window !== 'undefined' ? `${window.location.origin}/preview/${workout.ownerUsername}/${workout.id}` : '';
   const shareText = `🏋️ ${workout.name}${distance ? ` • ${distance} km` : ''}${duration ? ` • ${duration} min` : ''}${aiComment ? `\n${aiComment}` : ''}\n\nTracked on The Daily Athlete`;
 
   if (!isOpen) {

--- a/src/components/workouts/comments/CommentSection.tsx
+++ b/src/components/workouts/comments/CommentSection.tsx
@@ -10,6 +10,7 @@ import { MessageSquare } from 'lucide-react';
 import { toast } from 'sonner';
 
 interface CommentSectionProps {
+  ownerUsername: string;
   workoutId: string;
   workoutName: string;
   currentUserId: string;
@@ -19,6 +20,7 @@ interface CommentSectionProps {
 }
 
 export function CommentSection({
+  ownerUsername,
   workoutId,
   workoutName,
   currentUserId,
@@ -30,7 +32,7 @@ export function CommentSection({
   const [replyingTo, setReplyingTo] = useState<string | undefined>();
 
   const loadComments = async () => {
-    const data = await getWorkoutComments(workoutId);
+    const data = await getWorkoutComments(ownerUsername, workoutId);
     setComments(data);
     setLoading(false);
   };
@@ -42,6 +44,7 @@ export function CommentSection({
   const handleSubmit = async (text: string, rating?: WorkoutRating) => {
     try {
       await addWorkoutComment(
+        ownerUsername,
         workoutId,
         currentUserId,
         currentUserRole,
@@ -58,6 +61,7 @@ export function CommentSection({
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({
+              ownerUsername,
               workoutId,
               workoutName,
               commentText: text,
@@ -83,7 +87,7 @@ export function CommentSection({
     if (!confirm('Delete this comment?')) return;
 
     try {
-      await deleteWorkoutComment(workoutId, commentId);
+      await deleteWorkoutComment(ownerUsername, workoutId, commentId);
       toast.success('Comment deleted');
       await loadComments();
     } catch (error: any) {

--- a/src/lib/firebase/adminUserMapping.ts
+++ b/src/lib/firebase/adminUserMapping.ts
@@ -1,0 +1,33 @@
+import { getAdminDb } from './admin';
+
+export async function adminGetUsernameFromUid(uid: string): Promise<string | null> {
+  const db = getAdminDb();
+  const mappingDoc = await db.collection('userMappings').doc(uid).get();
+  if (mappingDoc.exists) {
+    return mappingDoc.data()?.username || null;
+  }
+  return null;
+}
+
+export async function adminGetUserByUsername(username: string): Promise<FirebaseFirestore.DocumentData | null> {
+  const db = getAdminDb();
+  const userDoc = await db.collection('users').doc(username).get();
+  if (userDoc.exists) {
+    return { username: userDoc.id, ...userDoc.data() };
+  }
+  return null;
+}
+
+export async function adminGetUserDocRef(username: string): Promise<FirebaseFirestore.DocumentReference> {
+  return getAdminDb().collection('users').doc(username);
+}
+
+/**
+ * Resolve a UID to username, throwing if not found.
+ * Use at the top of API routes that receive a UID.
+ */
+export async function adminResolveUsername(uid: string): Promise<string> {
+  const username = await adminGetUsernameFromUid(uid);
+  if (!username) throw new Error(`No username mapping found for UID: ${uid}`);
+  return username;
+}

--- a/src/lib/firebase/auth.ts
+++ b/src/lib/firebase/auth.ts
@@ -10,36 +10,87 @@ import {
   browserLocalPersistence,
   browserSessionPersistence,
 } from 'firebase/auth';
-import { doc, setDoc, getDoc, serverTimestamp, collection, query, where, getDocs } from 'firebase/firestore';
+import { doc, getDoc, serverTimestamp, writeBatch } from 'firebase/firestore';
 import { getAuthInstance, getDbInstance } from './config';
 import { User, UserRole } from '@/types';
+import { getUsernameFromUid } from './userMapping';
+
+// Result type for Google Sign-In (may need username selection)
+export type GoogleSignInResult =
+  | { type: 'existing'; user: User }
+  | { type: 'needs_username'; uid: string; email: string; displayName: string; photoURL?: string };
 
 export async function createUser(
   email: string,
   password: string,
   displayName: string,
+  username: string,
   role: UserRole,
-  coachId?: string
+  coachUsername?: string
 ): Promise<User> {
   try {
     const userCredential = await createUserWithEmailAndPassword(getAuthInstance(), email, password);
     const { uid } = userCredential.user;
 
-    const userProfile: Omit<User, 'createdAt' | 'updatedAt'> & { createdAt: any; updatedAt: any; } = {
+    const userProfile: Record<string, any> = {
       uid,
+      username,
       email,
       displayName,
       role,
       createdAt: serverTimestamp(),
       updatedAt: serverTimestamp(),
       onboardingCompleted: false,
-      ...(coachId ? { coachId } : {}),
     };
 
-    await setDoc(doc(getDbInstance(), 'users', uid), userProfile);
+    if (coachUsername) userProfile.coachUsername = coachUsername;
+
+    // Atomic write: user doc keyed by username + UID mapping
+    const db = getDbInstance();
+    const batch = writeBatch(db);
+    batch.set(doc(db, 'users', username), userProfile);
+    batch.set(doc(db, 'userMappings', uid), { username });
+    await batch.commit();
+
     return userProfile as User;
   } catch (error: any) {
     throw new Error(error.message || 'Failed to create user');
+  }
+}
+
+/**
+ * Create user doc for Google Sign-In users after they pick a username.
+ */
+export async function createGoogleUser(
+  uid: string,
+  email: string,
+  displayName: string,
+  username: string,
+  photoURL?: string,
+): Promise<User> {
+  try {
+    const db = getDbInstance();
+    const userProfile: Record<string, any> = {
+      uid,
+      username,
+      email,
+      displayName,
+      role: 'athlete' as UserRole,
+      createdAt: serverTimestamp(),
+      updatedAt: serverTimestamp(),
+      onboardingCompleted: false,
+    };
+
+    if (photoURL) userProfile.photoURL = photoURL;
+
+    const batch = writeBatch(db);
+    batch.set(doc(db, 'users', username), userProfile);
+    batch.set(doc(db, 'userMappings', uid), { username });
+    await batch.commit();
+
+    return userProfile as User;
+  } catch (error: any) {
+    throw new Error(error.message || 'Failed to create Google user');
   }
 }
 
@@ -62,41 +113,15 @@ export async function signOut(): Promise<void> {
   }
 }
 
-// Hardcoded coach config — rsareen@gmail.com auto-connects as coach to these athletes
-const AUTO_COACH_EMAIL = 'rsareen@gmail.com';
-const AUTO_COACH_ATHLETES = [
-  'rsareen+hetal@gmail.com',
-  'rsareen+rohin@gmail.com',
-  'rsareen+rupesh@gmail.com',
-];
-
 export async function getUserProfile(uid: string): Promise<User | null> {
   try {
-    const docRef = doc(getDbInstance(), 'users', uid);
-    const docSnap = await getDoc(docRef);
-    if (docSnap.exists()) {
-      const data = docSnap.data() as User;
+    // Look up username from UID mapping
+    const username = await getUsernameFromUid(uid);
+    if (!username) return null;
 
-      // Auto-promote rsareen@gmail.com to coach
-      if (data.email === AUTO_COACH_EMAIL && data.role !== 'coach') {
-        await setDoc(docRef, { role: 'coach', updatedAt: serverTimestamp() }, { merge: true });
-        return { ...data, role: 'coach' };
-      }
-
-      // Auto-assign athletes to their coach
-      if (AUTO_COACH_ATHLETES.includes(data.email || '') && !data.coachId) {
-        const coachSnap = await getDocs(query(
-          collection(getDbInstance(), 'users'),
-          where('email', '==', AUTO_COACH_EMAIL),
-        ));
-        if (!coachSnap.empty) {
-          const coachId = coachSnap.docs[0].id;
-          await setDoc(docRef, { coachId, role: 'athlete', updatedAt: serverTimestamp() }, { merge: true });
-          return { ...data, coachId, role: 'athlete' };
-        }
-      }
-
-      return data;
+    const userDoc = await getDoc(doc(getDbInstance(), 'users', username));
+    if (userDoc.exists()) {
+      return { username: userDoc.id, ...userDoc.data() } as User;
     }
     return null;
   } catch (error) {
@@ -109,8 +134,12 @@ export function onAuthChange(callback: (user: FirebaseUser | null) => void) {
   return onAuthStateChanged(getAuthInstance(), callback);
 }
 
-// Sign in with Google
-export async function signInWithGoogle(): Promise<User> {
+/**
+ * Google Sign-In with split flow:
+ * - Existing users: returns their profile
+ * - New users: returns pending data so they can pick a username
+ */
+export async function signInWithGoogle(): Promise<GoogleSignInResult> {
   try {
     const provider = new GoogleAuthProvider();
     const result = await signInWithPopup(getAuthInstance(), provider);
@@ -120,47 +149,24 @@ export async function signInWithGoogle(): Promise<User> {
       throw new Error('Google account does not have an email address');
     }
 
-    // Check if user already exists in Firestore
-    const existingUser = await getUserProfile(uid);
-
-    if (existingUser) {
-      // User exists, just return their profile
-      console.log('✅ Existing Google user signed in:', existingUser.displayName);
-      return existingUser;
+    // Check if user already has a mapping (existing user)
+    const username = await getUsernameFromUid(uid);
+    if (username) {
+      const profile = await getUserProfile(uid);
+      if (profile) {
+        return { type: 'existing', user: profile };
+      }
     }
 
-    // New user - create profile
-    const isAutoCoach = email === AUTO_COACH_EMAIL;
-    const isAutoAthlete = AUTO_COACH_ATHLETES.includes(email);
-
-    // If auto-athlete, find coach uid
-    let autoCoachId: string | undefined;
-    if (isAutoAthlete) {
-      const coachSnap = await getDocs(query(
-        collection(getDbInstance(), 'users'),
-        where('email', '==', AUTO_COACH_EMAIL),
-      ));
-      if (!coachSnap.empty) autoCoachId = coachSnap.docs[0].id;
-    }
-
-    const userProfile: Omit<User, 'createdAt' | 'updatedAt'> & { createdAt: any; updatedAt: any; photoURL?: string; coachId?: string } = {
+    // New user — needs to choose a username
+    return {
+      type: 'needs_username',
       uid,
       email,
       displayName: displayName || email.split('@')[0],
-      role: isAutoCoach ? 'coach' : 'athlete',
-      createdAt: serverTimestamp(),
-      updatedAt: serverTimestamp(),
-      onboardingCompleted: false,
-      ...(photoURL ? { photoURL } : {}),
-      ...(autoCoachId ? { coachId: autoCoachId } : {}),
+      photoURL: photoURL || undefined,
     };
-
-    await setDoc(doc(getDbInstance(), 'users', uid), userProfile);
-    console.log('✅ New Google user created:', userProfile.displayName);
-
-    return userProfile as User;
   } catch (error: any) {
-    // Handle specific popup errors
     if (error.code === 'auth/popup-closed-by-user') {
       throw new Error('Sign-in cancelled');
     }

--- a/src/lib/firebase/firestore.ts
+++ b/src/lib/firebase/firestore.ts
@@ -29,13 +29,16 @@ function getNextDate(currentDate: Date, frequency: string): Date {
   }
 }
 
-export async function createWorkout(data: ExtendedWorkoutFormData, createdBy: string): Promise<string> {
+export async function createWorkout(data: ExtendedWorkoutFormData, createdByUsername: string): Promise<string> {
   try {
+    const ownerUsername = data.assignedTo;
+
     const baseWorkoutData: any = {
       name: data.name,
       type: data.type,
-      createdBy,
+      createdBy: createdByUsername,
       assignedTo: data.assignedTo,
+      ownerUsername,
       completed: false,
       createdAt: serverTimestamp(),
       updatedAt: serverTimestamp(),
@@ -60,15 +63,15 @@ export async function createWorkout(data: ExtendedWorkoutFormData, createdBy: st
       const db = getDbInstance();
       const batch = writeBatch(db);
       const workoutIds: string[] = [];
-      
+
       let currentDate = new Date(data.date);
       const endDate = new Date(data.recurringEndDate);
       let isFirstWorkout = true;
       let firstWorkoutId = '';
-      
+
       // Create workouts from start date until end date
       while (currentDate <= endDate) {
-        const workoutRef = doc(collection(db, 'workouts'));
+        const workoutRef = doc(collection(db, 'users', ownerUsername, 'workouts'));
         const workoutData = {
           ...baseWorkoutData,
           date: Timestamp.fromDate(currentDate),
@@ -77,21 +80,21 @@ export async function createWorkout(data: ExtendedWorkoutFormData, createdBy: st
           createdAt: serverTimestamp(),
           updatedAt: serverTimestamp(),
         };
-        
+
         batch.set(workoutRef, workoutData);
         workoutIds.push(workoutRef.id);
-        
+
         if (isFirstWorkout) {
           firstWorkoutId = workoutRef.id;
           isFirstWorkout = false;
         }
-        
+
         // Move to next date based on frequency
         currentDate = getNextDate(currentDate, data.recurringFrequency);
       }
-      
+
       await batch.commit();
-      console.log(`✅ Created ${workoutIds.length} recurring workouts`);
+      console.log(`Created ${workoutIds.length} recurring workouts`);
       return firstWorkoutId;
     } else {
       // Single workout creation
@@ -99,7 +102,8 @@ export async function createWorkout(data: ExtendedWorkoutFormData, createdBy: st
         ...baseWorkoutData,
         date: Timestamp.fromDate(data.date),
       };
-      const docRef = await addDoc(collection(getDbInstance(), 'workouts'), workoutData);
+      const workoutsRef = collection(getDbInstance(), 'users', ownerUsername, 'workouts');
+      const docRef = await addDoc(workoutsRef, workoutData);
       return docRef.id;
     }
   } catch (error: any) {
@@ -107,9 +111,9 @@ export async function createWorkout(data: ExtendedWorkoutFormData, createdBy: st
   }
 }
 
-export async function getWorkout(id: string): Promise<Workout | null> {
+export async function getWorkout(ownerUsername: string, id: string): Promise<Workout | null> {
   try {
-    const docRef = doc(getDbInstance(), 'workouts', id);
+    const docRef = doc(getDbInstance(), 'users', ownerUsername, 'workouts', id);
     const docSnap = await getDoc(docRef);
     if (docSnap.exists()) {
       return { id: docSnap.id, ...docSnap.data() } as Workout;
@@ -121,16 +125,17 @@ export async function getWorkout(id: string): Promise<Workout | null> {
   }
 }
 
-export async function getUserWorkouts(userId: string, role: 'coach' | 'athlete' | 'student'): Promise<Workout[]> {
+export async function getUserWorkouts(username: string, role: 'coach' | 'athlete' | 'student'): Promise<Workout[]> {
   try {
-    const workoutsRef = collection(getDbInstance(), 'workouts');
+    const db = getDbInstance();
 
     // Handle both 'athlete' and legacy 'student' role
     if (role === 'athlete' || role === 'student') {
-      // Athletes see workouts assigned to them
-      const q = query(workoutsRef, where('assignedTo', '==', userId), orderBy('date', 'desc'));
+      // Athletes see workouts in their own subcollection
+      const workoutsRef = collection(db, 'users', username, 'workouts');
+      const q = query(workoutsRef, orderBy('date', 'desc'));
       const querySnapshot = await getDocs(q);
-      const allWorkouts = querySnapshot.docs.map(doc => ({ id: doc.id, ...doc.data() })) as Workout[];
+      const allWorkouts = querySnapshot.docs.map(d => ({ id: d.id, ...d.data() })) as Workout[];
 
       // Hide recurring workouts that are more than 2 days in the future
       const twoDaysFromNow = addDays(new Date(), 2);
@@ -141,57 +146,47 @@ export async function getUserWorkouts(userId: string, role: 'coach' | 'athlete' 
       });
     } else {
       // Coaches see:
-      // 1. Workouts they created (createdBy = coachId)
-      // 2. Workouts assigned to their students (including Strava imports)
-      
+      // 1. Workouts they created (createdBy = coachUsername) across students
+      // 2. Workouts in their students' subcollections (including Strava imports)
+
       // Get coach's students
-      const students = await getCoachStudents(userId);
-      const studentIds = students.map(s => s.uid);
-      
-      // Query 1: Workouts created by coach
-      const coachWorkoutsQuery = query(
-        workoutsRef, 
-        where('createdBy', '==', userId), 
-        orderBy('date', 'desc')
-      );
-      const coachWorkouts = await getDocs(coachWorkoutsQuery);
-      
-      // Query 2: Workouts assigned to students (Strava imports + file imports)
-      // We need to fetch these separately since Firestore doesn't support OR queries well
-      const studentWorkouts: Workout[] = [];
-      
-      if (studentIds.length > 0) {
-        // Firestore 'in' supports max 10 items, so batch if needed
-        const batches = [];
-        for (let i = 0; i < studentIds.length; i += 10) {
-          const batch = studentIds.slice(i, i + 10);
-          batches.push(batch);
+      const students = await getCoachStudents(username);
+
+      const allWorkouts: Workout[] = [];
+
+      // For each student, query their workout subcollection
+      for (const student of students) {
+        const studentUsername = student.uid; // uid field contains username (doc.id)
+        const studentWorkoutsRef = collection(db, 'users', studentUsername, 'workouts');
+
+        // Get strava and import source workouts
+        const [stravaDocs, importDocs, coachCreatedDocs] = await Promise.all([
+          getDocs(query(studentWorkoutsRef, where('source', '==', 'strava'))),
+          getDocs(query(studentWorkoutsRef, where('source', '==', 'import'))),
+          getDocs(query(studentWorkoutsRef, where('createdBy', '==', username))),
+        ]);
+
+        const studentWorkouts = [
+          ...stravaDocs.docs.map(d => ({ id: d.id, ...d.data() }) as Workout),
+          ...importDocs.docs.map(d => ({ id: d.id, ...d.data() }) as Workout),
+          ...coachCreatedDocs.docs.map(d => ({ id: d.id, ...d.data() }) as Workout),
+        ];
+
+        // Enrich with athlete name
+        for (const w of studentWorkouts) {
+          if (!w.assignedToName) {
+            w.assignedToName = student.displayName || undefined;
+          }
         }
-        
-        // Fetch both strava and import sources (can't use two 'in' operators)
-        for (const batch of batches) {
-          const [stravaDocs, importDocs] = await Promise.all([
-            getDocs(query(workoutsRef, where('assignedTo', 'in', batch), where('source', '==', 'strava'))),
-            getDocs(query(workoutsRef, where('assignedTo', 'in', batch), where('source', '==', 'import'))),
-          ]);
-          studentWorkouts.push(
-            ...stravaDocs.docs.map(doc => ({ id: doc.id, ...doc.data() }) as Workout),
-            ...importDocs.docs.map(doc => ({ id: doc.id, ...doc.data() }) as Workout),
-          );
-        }
+
+        allWorkouts.push(...studentWorkouts);
       }
-      
-      // Combine and deduplicate
-      const allWorkouts = [
-        ...coachWorkouts.docs.map(doc => ({ id: doc.id, ...doc.data() }) as Workout),
-        ...studentWorkouts
-      ];
-      
+
       // Remove duplicates by ID
       const uniqueWorkouts = Array.from(
         new Map(allWorkouts.map(w => [w.id, w])).values()
       );
-      
+
       // Sort by date descending
       uniqueWorkouts.sort((a, b) => {
         const dateA = a.date?.toDate ? a.date.toDate() : (a.date as any);
@@ -200,14 +195,6 @@ export async function getUserWorkouts(userId: string, role: 'coach' | 'athlete' 
         const timeB = dateB instanceof Date ? dateB.getTime() : new Date(dateB).getTime();
         return timeB - timeA;
       });
-      
-      // Enrich workouts with athlete names for coach view
-      const nameMap = new Map(students.map(s => [s.uid, s.displayName]));
-      for (const w of uniqueWorkouts) {
-        if (!w.assignedToName && w.assignedTo && w.assignedTo !== userId) {
-          w.assignedToName = nameMap.get(w.assignedTo) || undefined;
-        }
-      }
 
       return uniqueWorkouts;
     }
@@ -217,9 +204,9 @@ export async function getUserWorkouts(userId: string, role: 'coach' | 'athlete' 
   }
 }
 
-export async function updateWorkout(id: string, data: Partial<WorkoutFormData>): Promise<void> {
+export async function updateWorkout(ownerUsername: string, id: string, data: Partial<WorkoutFormData>): Promise<void> {
   try {
-    const docRef = doc(getDbInstance(), 'workouts', id);
+    const docRef = doc(getDbInstance(), 'users', ownerUsername, 'workouts', id);
     const updateData: any = { updatedAt: serverTimestamp() };
 
     // Copy only defined values (Firestore rejects undefined)
@@ -248,17 +235,17 @@ export async function updateWorkout(id: string, data: Partial<WorkoutFormData>):
   }
 }
 
-export async function deleteWorkout(id: string): Promise<void> {
+export async function deleteWorkout(ownerUsername: string, id: string): Promise<void> {
   try {
-    await deleteDoc(doc(getDbInstance(), 'workouts', id));
+    await deleteDoc(doc(getDbInstance(), 'users', ownerUsername, 'workouts', id));
   } catch (error: any) {
     throw new Error(error.message || 'Failed to delete workout');
   }
 }
 
-export async function toggleWorkoutCompletion(id: string, completed: boolean): Promise<void> {
+export async function toggleWorkoutCompletion(ownerUsername: string, id: string, completed: boolean): Promise<void> {
   try {
-    const docRef = doc(getDbInstance(), 'workouts', id);
+    const docRef = doc(getDbInstance(), 'users', ownerUsername, 'workouts', id);
     await updateDoc(docRef, { completed, updatedAt: serverTimestamp() });
   } catch (error: any) {
     throw new Error(error.message || 'Failed to update workout status');
@@ -267,19 +254,20 @@ export async function toggleWorkoutCompletion(id: string, completed: boolean): P
 
 // Enhanced completion with notes and rating
 export async function completeWorkout(
+  ownerUsername: string,
   id: string,
   completed: boolean,
   notes?: string
 ): Promise<void> {
   try {
-    const docRef = doc(getDbInstance(), 'workouts', id);
-    
+    const docRef = doc(getDbInstance(), 'users', ownerUsername, 'workouts', id);
+
     // Get workout to check if completion is late
     const workoutSnap = await getDoc(docRef);
     if (!workoutSnap.exists()) {
       throw new Error('Workout not found');
     }
-    
+
     const updateData: Record<string, any> = {
       completed,
       updatedAt: serverTimestamp(),
@@ -288,24 +276,24 @@ export async function completeWorkout(
     if (completed) {
       const now = new Date();
       const workoutDate = workoutSnap.data().date.toDate();
-      
+
       // Set workout date to end of day for fair comparison
       workoutDate.setHours(23, 59, 59, 999);
-      
+
       // Check if completing after due date
       const isLate = now > workoutDate;
-      
-      console.log('🔍 Late completion check:', {
+
+      console.log('Late completion check:', {
         now: now.toISOString(),
         workoutDate: workoutDate.toISOString(),
         isLate,
         workoutName: workoutSnap.data().name
       });
-      
+
       updateData.completedAt = serverTimestamp();
       updateData.completedBy = 'manual';
       updateData.completedLate = isLate;
-      
+
       if (notes) {
         updateData.completionNotes = notes;
       }
@@ -325,6 +313,7 @@ export async function completeWorkout(
 
 // Workout Comments Functions
 export async function addWorkoutComment(
+  ownerUsername: string,
   workoutId: string,
   userId: string,
   userRole: 'coach' | 'athlete' | 'student',
@@ -334,7 +323,7 @@ export async function addWorkoutComment(
   parentCommentId?: string
 ): Promise<string> {
   try {
-    const commentsRef = collection(getDbInstance(), 'workouts', workoutId, 'comments');
+    const commentsRef = collection(getDbInstance(), 'users', ownerUsername, 'workouts', workoutId, 'comments');
     const commentData: Omit<WorkoutComment, 'id'> = {
       workoutId,
       userId,
@@ -353,57 +342,50 @@ export async function addWorkoutComment(
   }
 }
 
-export async function getWorkoutComments(workoutId: string): Promise<WorkoutComment[]> {
+export async function getWorkoutComments(ownerUsername: string, workoutId: string): Promise<WorkoutComment[]> {
   try {
-    const commentsRef = collection(getDbInstance(), 'workouts', workoutId, 'comments');
+    const commentsRef = collection(getDbInstance(), 'users', ownerUsername, 'workouts', workoutId, 'comments');
     const q = query(commentsRef, orderBy('createdAt', 'asc'));
     const snapshot = await getDocs(q);
-    return snapshot.docs.map(doc => ({ id: doc.id, ...doc.data() })) as WorkoutComment[];
+    return snapshot.docs.map(d => ({ id: d.id, ...d.data() })) as WorkoutComment[];
   } catch (error) {
     console.error('Error fetching comments:', error);
     return [];
   }
 }
 
-export async function deleteWorkoutComment(workoutId: string, commentId: string): Promise<void> {
+export async function deleteWorkoutComment(ownerUsername: string, workoutId: string, commentId: string): Promise<void> {
   try {
-    const commentRef = doc(getDbInstance(), 'workouts', workoutId, 'comments', commentId);
+    const commentRef = doc(getDbInstance(), 'users', ownerUsername, 'workouts', workoutId, 'comments', commentId);
     await deleteDoc(commentRef);
   } catch (error: any) {
     throw new Error(error.message || 'Failed to delete comment');
   }
 }
 
-export async function getCoachStudents(coachId: string): Promise<any[]> {
+export async function getCoachStudents(coachUsername: string): Promise<any[]> {
   try {
-    // Get coach's user document
-    const coachDoc = await getDoc(doc(getDbInstance(), 'users', coachId));
-
     const usersRef = collection(getDbInstance(), 'users');
 
     // Query for both 'athlete' and legacy 'student' roles
     // Firestore doesn't support OR in where, so we run two queries
-    let athletes: any[] = [];
-
-    // Coaches only see athletes assigned to them
-    console.log('👤 Fetching assigned athletes only');
-    const athleteQuery = query(usersRef, where('coachId', '==', coachId), where('role', '==', 'athlete'));
-    const studentQuery = query(usersRef, where('coachId', '==', coachId), where('role', '==', 'student'));
+    const athleteQuery = query(usersRef, where('coachUsername', '==', coachUsername), where('role', '==', 'athlete'));
+    const studentQuery = query(usersRef, where('coachUsername', '==', coachUsername), where('role', '==', 'student'));
 
     const [athleteSnapshot, studentSnapshot] = await Promise.all([
       getDocs(athleteQuery),
       getDocs(studentQuery)
     ]);
 
-    athletes = [
-      ...athleteSnapshot.docs.map(doc => ({ uid: doc.id, ...doc.data() })),
-      ...studentSnapshot.docs.map(doc => ({ uid: doc.id, ...doc.data() }))
+    const athletes = [
+      ...athleteSnapshot.docs.map(d => ({ uid: d.id, ...d.data() })),
+      ...studentSnapshot.docs.map(d => ({ uid: d.id, ...d.data() }))
     ];
 
-    console.log('📊 Found athletes:', athletes.length);
+    console.log('Found athletes:', athletes.length);
     return athletes;
   } catch (error) {
-    console.error('❌ Error fetching students:', error);
+    console.error('Error fetching students:', error);
     return [];
   }
 }
@@ -434,13 +416,13 @@ export interface CoachStats {
   studentsWithStats: StudentWithStats[];
 }
 
-export async function getCoachDashboardStats(coachId: string): Promise<CoachStats> {
+export async function getCoachDashboardStats(coachUsername: string): Promise<CoachStats> {
   try {
     // Get students
-    const students = await getCoachStudents(coachId);
+    const students = await getCoachStudents(coachUsername);
 
-    // Get all workouts created by this coach
-    const workouts = await getUserWorkouts(coachId, 'coach');
+    // Get all workouts visible to this coach
+    const workouts = await getUserWorkouts(coachUsername, 'coach');
 
     // Calculate workout stats
     const completedWorkouts = workouts.filter(w => w.completed).length;
@@ -469,7 +451,8 @@ export async function getCoachDashboardStats(coachId: string): Promise<CoachStat
     sevenDaysAgo.setDate(sevenDaysAgo.getDate() - 7);
 
     const studentsWithStats: StudentWithStats[] = students.map(student => {
-      const studentWorkouts = workouts.filter(w => w.assignedTo === student.uid);
+      const studentUsername = student.uid; // uid contains username (doc.id)
+      const studentWorkouts = workouts.filter(w => w.assignedTo === studentUsername);
       const studentCompleted = studentWorkouts.filter(w => w.completed);
 
       // Check if student completed any workout in last 7 days
@@ -525,10 +508,10 @@ export async function getCoachDashboardStats(coachId: string): Promise<CoachStat
   }
 }
 
-// Get coach info by ID
-export async function getCoachInfo(coachId: string): Promise<{ uid: string; displayName: string; email: string } | null> {
+// Get coach info by username
+export async function getCoachInfo(coachUsername: string): Promise<{ uid: string; displayName: string; email: string } | null> {
   try {
-    const coachDoc = await getDoc(doc(getDbInstance(), 'users', coachId));
+    const coachDoc = await getDoc(doc(getDbInstance(), 'users', coachUsername));
     if (coachDoc.exists()) {
       const data = coachDoc.data();
       return {
@@ -546,7 +529,7 @@ export async function getCoachInfo(coachId: string): Promise<{ uid: string; disp
 
 // Update user's Strava connection
 export async function updateUserStravaConnection(
-  userId: string,
+  username: string,
   stravaData: {
     stravaId: string;
     stravaAccessToken: string;
@@ -555,7 +538,7 @@ export async function updateUserStravaConnection(
   }
 ): Promise<void> {
   try {
-    const userRef = doc(getDbInstance(), 'users', userId);
+    const userRef = doc(getDbInstance(), 'users', username);
     await updateDoc(userRef, {
       ...stravaData,
       stravaConnectedAt: serverTimestamp(),
@@ -567,9 +550,9 @@ export async function updateUserStravaConnection(
 }
 
 // Disconnect Strava
-export async function disconnectStrava(userId: string): Promise<void> {
+export async function disconnectStrava(username: string): Promise<void> {
   try {
-    const userRef = doc(getDbInstance(), 'users', userId);
+    const userRef = doc(getDbInstance(), 'users', username);
     await updateDoc(userRef, {
       stravaId: null,
       stravaAccessToken: null,
@@ -589,7 +572,7 @@ export async function getPersonalRecords(userId: string): Promise<PersonalRecord
     const recordsRef = collection(getDbInstance(), 'personalRecords');
     const q = query(recordsRef, where('userId', '==', userId), orderBy('date', 'desc'));
     const snapshot = await getDocs(q);
-    return snapshot.docs.map(doc => ({ id: doc.id, ...doc.data() })) as PersonalRecord[];
+    return snapshot.docs.map(d => ({ id: d.id, ...d.data() })) as PersonalRecord[];
   } catch (error) {
     console.error('Error fetching personal records:', error);
     return [];
@@ -714,7 +697,7 @@ export async function updatePersonalRecord(
     const updateData: Record<string, any> = {
       updatedAt: serverTimestamp(),
     };
-    
+
     // Only add fields that are defined
     if (data.value !== undefined) {
       updateData.value = data.value;
@@ -725,7 +708,7 @@ export async function updatePersonalRecord(
     if (data.notes !== undefined && data.notes !== '') {
       updateData.notes = data.notes;
     }
-    
+
     await updateDoc(recordRef, updateData);
   } catch (error: any) {
     throw new Error(error.message || 'Failed to update personal record');

--- a/src/lib/firebase/userMapping.ts
+++ b/src/lib/firebase/userMapping.ts
@@ -1,0 +1,47 @@
+import { doc, getDoc } from 'firebase/firestore';
+import { getDbInstance } from './config';
+
+export const USERNAME_REGEX = /^[a-z0-9_]{3,20}$/;
+
+export const RESERVED_USERNAMES = [
+  'admin', 'api', 'preview', 'settings', 'profile', 'dashboard',
+  'workouts', 'calendar', 'reports', 'login', 'register', 'onboarding',
+  'coach', 'athlete', 'help', 'support', 'about', 'contact',
+  'ai-coach', 'suggestions', 'features', 'connect-strava',
+];
+
+export function validateUsername(username: string): { valid: boolean; error?: string } {
+  if (!username) return { valid: false, error: 'Username is required' };
+  if (username.length < 3) return { valid: false, error: 'Username must be at least 3 characters' };
+  if (username.length > 20) return { valid: false, error: 'Username must be 20 characters or less' };
+  if (!USERNAME_REGEX.test(username)) {
+    return { valid: false, error: 'Username can only contain lowercase letters, numbers, and underscores' };
+  }
+  if (RESERVED_USERNAMES.includes(username)) {
+    return { valid: false, error: 'This username is reserved' };
+  }
+  return { valid: true };
+}
+
+export async function getUsernameFromUid(uid: string): Promise<string | null> {
+  try {
+    const mappingDoc = await getDoc(doc(getDbInstance(), 'userMappings', uid));
+    if (mappingDoc.exists()) {
+      return mappingDoc.data().username;
+    }
+    return null;
+  } catch (error) {
+    console.error('Error looking up username for UID:', error);
+    return null;
+  }
+}
+
+export async function isUsernameAvailable(username: string): Promise<boolean> {
+  try {
+    const userDoc = await getDoc(doc(getDbInstance(), 'users', username));
+    return !userDoc.exists();
+  } catch (error) {
+    console.error('Error checking username availability:', error);
+    return false;
+  }
+}

--- a/src/lib/groq-dedup.ts
+++ b/src/lib/groq-dedup.ts
@@ -62,10 +62,9 @@ If no duplicates found, respond: {"duplicates":[]}`;
 /**
  * Fetch all workouts for a user, formatted for Groq analysis
  */
-async function fetchUserWorkouts(userId: string): Promise<WorkoutSummary[]> {
+async function fetchUserWorkouts(username: string): Promise<WorkoutSummary[]> {
   const snapshot = await adminDb
-    .collection('workouts')
-    .where('assignedTo', '==', userId)
+    .collection('users').doc(username).collection('workouts')
     .orderBy('date', 'desc')
     .limit(200) // Cap to keep under token limits
     .get();
@@ -221,11 +220,11 @@ function deterministicDedup(workouts: WorkoutSummary[]): DedupResult {
  * Main dedup pipeline: Groq first, deterministic fallback.
  * Returns structured result. Does NOT delete — caller decides.
  */
-export async function runDedupPipeline(userId: string): Promise<{
+export async function runDedupPipeline(username: string): Promise<{
   workouts: WorkoutSummary[];
   result: DedupResult;
 }> {
-  const workouts = await fetchUserWorkouts(userId);
+  const workouts = await fetchUserWorkouts(username);
   if (workouts.length < 2) {
     return {
       workouts,
@@ -253,12 +252,12 @@ export async function runDedupPipeline(userId: string): Promise<{
 /**
  * Execute deletions from a dedup result
  */
-export async function executeDedupDeletions(result: DedupResult): Promise<number> {
+export async function executeDedupDeletions(result: DedupResult, username: string): Promise<number> {
   if (result.deletions.length === 0) return 0;
 
   const batch = adminDb.batch();
   for (const d of result.deletions) {
-    batch.delete(adminDb.collection('workouts').doc(d.deleteId));
+    batch.delete(adminDb.collection('users').doc(username).collection('workouts').doc(d.deleteId));
   }
   await batch.commit();
   return result.deletions.length;

--- a/src/lib/stores/authStore.ts
+++ b/src/lib/stores/authStore.ts
@@ -1,29 +1,61 @@
 import { create } from 'zustand';
 import { User } from '@/types';
 
+interface PendingGoogleUser {
+  uid: string;
+  email: string;
+  displayName: string;
+  photoURL?: string;
+}
+
 interface AuthState {
   user: User | null;
   loading: boolean;
+  needsUsername: boolean;
+  pendingGoogleUser: PendingGoogleUser | null;
   setUser: (user: User | null) => void;
   setLoading: (loading: boolean) => void;
+  setNeedsUsername: (needs: boolean, pending?: PendingGoogleUser | null) => void;
   initialize: () => void;
 }
 
 export const useAuthStore = create<AuthState>((set) => ({
   user: null,
   loading: true,
+  needsUsername: false,
+  pendingGoogleUser: null,
   setUser: (user) => set({ user }),
   setLoading: (loading) => set({ loading }),
+  setNeedsUsername: (needs, pending = null) => set({ needsUsername: needs, pendingGoogleUser: pending }),
   initialize: async () => {
     // Dynamic import to prevent Firebase loading during SSR/build
     const { onAuthChange, getUserProfile } = await import('@/lib/firebase/auth');
-    
+    const { getUsernameFromUid } = await import('@/lib/firebase/userMapping');
+
     onAuthChange(async (firebaseUser) => {
       if (firebaseUser) {
+        // Check if user has a username mapping
+        const username = await getUsernameFromUid(firebaseUser.uid);
+        if (!username) {
+          // Firebase auth exists but no user doc yet (Google sign-in, needs username)
+          set({
+            user: null,
+            loading: false,
+            needsUsername: true,
+            pendingGoogleUser: {
+              uid: firebaseUser.uid,
+              email: firebaseUser.email || '',
+              displayName: firebaseUser.displayName || '',
+              photoURL: firebaseUser.photoURL || undefined,
+            },
+          });
+          return;
+        }
+
         const userProfile = await getUserProfile(firebaseUser.uid);
-        set({ user: userProfile, loading: false });
+        set({ user: userProfile, loading: false, needsUsername: false, pendingGoogleUser: null });
       } else {
-        set({ user: null, loading: false });
+        set({ user: null, loading: false, needsUsername: false, pendingGoogleUser: null });
       }
     });
   },

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -10,12 +10,13 @@ export type { WorkoutTag };
 
 export interface User {
   uid: string;
+  username: string; // Document key in users/{username}
   email: string;
   displayName: string;
   role: UserRole;
   createdAt: Timestamp;
   updatedAt: Timestamp;
-  coachId?: string;
+  coachUsername?: string; // Username of coach (was coachId)
   coachCode?: string; // 6-letter code for coaches
   photoURL?: string; // Google profile photo
   // Strava integration fields
@@ -80,10 +81,11 @@ export interface Workout {
   date: Timestamp;
   duration?: number;
   tags?: WorkoutTag[]; // NEW: Workout tags
-  createdBy: string;
-  assignedTo: string;
+  ownerUsername: string; // Username of the athlete who owns this workout (subcollection parent)
+  createdBy: string; // Username of creator (coach or self)
+  assignedTo: string; // Username of assigned athlete
   assignedToName?: string; // athlete display name for coach view
-  studentId?: string; // alias for assignedTo used in some components
+  studentId?: string; // legacy alias for assignedTo
   completed: boolean;
   createdAt: Timestamp;
   updatedAt: Timestamp;
@@ -194,6 +196,6 @@ export interface AuthContextType {
   user: User | null;
   loading: boolean;
   signIn: (email: string, password: string) => Promise<void>;
-  signUp: (email: string, password: string, displayName: string, role: UserRole) => Promise<void>;
+  signUp: (email: string, password: string, displayName: string, username: string, role: UserRole) => Promise<void>;
   signOut: () => Promise<void>;
 }


### PR DESCRIPTION
…llections

Complete codebase migration from flat `users/{uid}` + `workouts/{id}` schema to `users/{username}` + `users/{username}/workouts/{id}` subcollection schema with `userMappings/{uid}` for reverse lookups.

Key changes across 56 files:
- Types: added username to User, coachId→coachUsername, ownerUsername on Workout
- Auth: atomic user+mapping creation, Google sign-in split flow with /choose-username
- Firestore CRUD: all workout ops take ownerUsername, subcollection paths
- API routes (~30 files): subcollection paths, collectionGroup for cross-user queries
- UI pages (~10 files): user.uid→user.username in all Firestore calls
- Preview: moved from /preview/[id] to /preview/[username]/[id]
- Dedup: executeDedupDeletions now takes username param