### PR TITLE
fix: redirect to choose-username when Firestore profile missing

### DIFF
--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -10,8 +10,13 @@ export default function LoginPage() {
   const router = useRouter();
   const user = useAuthStore((state) => state.user);
   const loading = useAuthStore((state) => state.loading);
+  const needsUsername = useAuthStore((state) => state.needsUsername);
 
   useEffect(() => {
+    if (!loading && needsUsername) {
+      router.replace('/choose-username');
+      return;
+    }
     if (!loading && user) {
       if (user.onboardingCompleted === false) {
         router.replace('/onboarding');
@@ -19,7 +24,7 @@ export default function LoginPage() {
         router.replace('/dashboard');
       }
     }
-  }, [user, loading, router]);
+  }, [user, loading, needsUsername, router]);
 
   if (loading || user) {
     return (

--- a/src/app/(dashboard)/layout.tsx
+++ b/src/app/(dashboard)/layout.tsx
@@ -11,9 +11,15 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
   const pathname = usePathname();
   const user = useAuthStore((state) => state.user);
   const loading = useAuthStore((state) => state.loading);
+  const needsUsername = useAuthStore((state) => state.needsUsername);
 
   useEffect(() => {
     if (loading) return;
+
+    if (needsUsername) {
+      router.replace('/choose-username');
+      return;
+    }
 
     if (!user) {
       router.replace('/login');
@@ -27,7 +33,7 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
     }
 
     // Onboarding page is always accessible — finish/skip handlers route out
-  }, [user, loading, pathname, router]);
+  }, [user, loading, needsUsername, pathname, router]);
 
   if (loading) {
     return (

--- a/src/components/auth/LoginForm.tsx
+++ b/src/components/auth/LoginForm.tsx
@@ -20,8 +20,13 @@ export function LoginForm() {
   const [waitingForAuth, setWaitingForAuth] = useState(false);
   const router = useRouter();
   const user = useAuthStore((state) => state.user);
+  const needsUsername = useAuthStore((state) => state.needsUsername);
 
   useEffect(() => {
+    if (waitingForAuth && needsUsername) {
+      router.replace('/choose-username');
+      return;
+    }
     if (waitingForAuth && user) {
       if (user.onboardingCompleted === false) {
         router.replace('/onboarding');
@@ -29,7 +34,7 @@ export function LoginForm() {
         router.replace('/dashboard');
       }
     }
-  }, [waitingForAuth, user, router]);
+  }, [waitingForAuth, user, needsUsername, router]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();


### PR DESCRIPTION
## Summary
- Fixes login hang when Firebase Auth user exists but Firestore profile (userMappings) is missing (e.g., after DB wipe)
- LoginForm, login page, and dashboard layout now check `needsUsername` and redirect to `/choose-username`

## Test plan
- [ ] Log in with email/password when no Firestore profile exists — should redirect to choose-username
- [ ] Visit /dashboard directly with stale session — should redirect to choose-username
- [ ] Normal login flow with existing profile still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)