### PR TITLE
fix: registration race condition after schema migration

### DIFF
--- a/src/components/auth/RegisterForm.tsx
+++ b/src/components/auth/RegisterForm.tsx
@@ -25,6 +25,7 @@ export function RegisterForm() {
   const [usernameError, setUsernameError] = useState('');
   const [usernameChecking, setUsernameChecking] = useState(false);
   const router = useRouter();
+  const setUser = useAuthStore((s) => s.setUser);
   const setNeedsUsername = useAuthStore((s) => s.setNeedsUsername);
 
   const handleGoogleSignUp = async () => {
@@ -120,13 +121,18 @@ export function RegisterForm() {
     }
 
     try {
-      await createUser(
+      const user = await createUser(
         formData.email,
         formData.password,
         trimmedName,
         formData.username,
         'athlete'
       );
+
+      // Update store before navigating — prevents race with onAuthStateChanged
+      // which fires before the Firestore batch commits and sets needsUsername: true
+      setUser(user);
+      setNeedsUsername(false);
 
       toast.success('Account created successfully');
       router.push('/onboarding');


### PR DESCRIPTION
## Summary
- Fix registration redirecting to `/choose-username` instead of `/onboarding` after the UID-to-username schema migration
- `createUserWithEmailAndPassword` triggers `onAuthStateChanged` before the Firestore batch commits, causing the auth store to set `needsUsername: true`
- Update auth store with the new user before navigating (matching the pattern in `choose-username`)

## Test plan
- [ ] Register a new account with email/password — should land on `/onboarding`
- [ ] Register with Google — should still go through choose-username flow correctly
- [ ] Existing users should log in normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)