### PR TITLE
fix: Strava OAuth sends username instead of UID

### DIFF
--- a/src/app/(dashboard)/onboarding/page.tsx
+++ b/src/app/(dashboard)/onboarding/page.tsx
@@ -106,7 +106,7 @@ export default function OnboardingPage() {
       if (connectStrava) {
         // Redirect to Strava OAuth — it will come back to /settings?strava=connected
         // then user lands on dashboard
-        window.location.href = `/api/auth/strava/authorize?userId=${user.username}`;
+        window.location.href = `/api/auth/strava/authorize?userId=${user.uid}`;
         return;
       }
 

--- a/src/app/(dashboard)/settings/page.tsx
+++ b/src/app/(dashboard)/settings/page.tsx
@@ -44,7 +44,7 @@ function SettingsContent() {
     }
   }, [searchParams, router]);
 
-  const handleConnectStrava = () => { setIsConnectingStrava(true); window.location.href = `/api/auth/strava/authorize?userId=${user?.username}`; };
+  const handleConnectStrava = () => { setIsConnectingStrava(true); window.location.href = `/api/auth/strava/authorize?userId=${user?.uid}`; };
 
   const handleDisconnectStrava = async () => {
     if (!user) return;

--- a/src/app/api/auth/strava/callback/route.ts
+++ b/src/app/api/auth/strava/callback/route.ts
@@ -96,7 +96,7 @@ export async function GET(request: NextRequest) {
 
     // Redirect back to settings with success
     return NextResponse.redirect(
-      new URL('/settings?strava=success', baseUrl)
+      new URL('/settings?strava=connected', baseUrl)
     );
   } catch (error: any) {
     console.error('❌ Strava callback error:', error);


### PR DESCRIPTION
## Summary
- Settings and onboarding pages send `user.username` to `/api/auth/strava/authorize`, but the callback expects a UID to resolve via `userMappings/{uid}`
- This was broken during the UID-to-username schema migration
- Also fixes callback redirect using `strava=success` when settings page checks for `strava=connected`

## Changes
- `settings/page.tsx`: `user?.username` → `user?.uid` in authorize URL
- `onboarding/page.tsx`: `user.username` → `user.uid` in authorize URL
- `strava/callback/route.ts`: `strava=success` → `strava=connected`

## Test plan
- [ ] Connect Strava from settings page — should complete OAuth flow
- [ ] Connect Strava from onboarding — should complete OAuth flow
- [ ] Success toast should show after connection

🤖 Generated with [Claude Code](https://claude.com/claude-code)