### PR TITLE
fix: auto-sync passes UID instead of username to sync API

### DIFF
--- a/src/hooks/useStravaAutoSync.ts
+++ b/src/hooks/useStravaAutoSync.ts
@@ -107,7 +107,7 @@ export function useStravaAutoSync(
 
     hasFired.current = true;
     console.log('[auto-sync] firing background Strava sync');
-    runSync(user.uid);
+    runSync(user.username);
   }, [user, runSync]);
 
   return { syncing, syncResult };


### PR DESCRIPTION
## Summary
- `useStravaAutoSync` hook called `runSync(user.uid)` but the sync API route looks up `users/{userId}` by document key, which is now the username
- Auto-sync silently failed with "User not found" on every page load since the schema migration

## Changes
- `src/hooks/useStravaAutoSync.ts`: `user.uid` → `user.username`

## Test plan
- [ ] Navigate to dashboard with Strava connected — auto-sync should work
- [ ] Check Vercel logs for successful sync messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)