### PR TITLE
feat: profile edit fields, onboarding redirect, progressive Strava sync

### DIFF
--- a/src/app/(dashboard)/onboarding/page.tsx
+++ b/src/app/(dashboard)/onboarding/page.tsx
@@ -106,7 +106,7 @@ export default function OnboardingPage() {
       if (connectStrava) {
         // Redirect to Strava OAuth — it will come back to /settings?strava=connected
         // then user lands on dashboard
-        window.location.href = `/api/auth/strava/authorize?userId=${user.uid}`;
+        window.location.href = `/api/auth/strava/authorize?userId=${user.uid}&from=onboarding`;
         return;
       }
 

--- a/src/app/(dashboard)/profile/page.tsx
+++ b/src/app/(dashboard)/profile/page.tsx
@@ -5,7 +5,7 @@ import { useRouter, useSearchParams } from 'next/navigation';
 import { useAuthStore } from '@/lib/stores/authStore';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { profileSchema, ProfileFormData, SPORT_OPTIONS, TRAINING_FOR_OPTIONS } from '@/lib/schemas/profile';
+import { profileSchema, ProfileFormData, SPORT_OPTIONS, TRAINING_FOR_OPTIONS, AGE_RANGE_OPTIONS, EXPERIENCE_LEVEL_OPTIONS } from '@/lib/schemas/profile';
 import { User } from '@/types';
 import { doc, updateDoc, serverTimestamp } from 'firebase/firestore';
 import { getDbInstance } from '@/lib/firebase/config';
@@ -59,6 +59,12 @@ function getDefaultValues(user: User | null): ProfileFormData {
     displayName: user?.displayName || '',
     bio: user?.bio || '',
     timezone: user?.timezone || Intl.DateTimeFormat().resolvedOptions().timeZone,
+    ageRange: user?.ageRange || '',
+    experienceLevel: user?.experienceLevel || '',
+    height: user?.height || null,
+    heightUnit: user?.heightUnit || 'cm',
+    weight: user?.weight || null,
+    weightUnit: user?.weightUnit || 'kg',
     sportPreferences: user?.sportPreferences || [],
     trainingFor: user?.trainingFor || [],
     notificationPreferences: user?.notificationPreferences || {
@@ -165,6 +171,12 @@ export default function ProfilePage() {
         displayName: data.displayName,
         bio: data.bio || null,
         timezone: data.timezone || null,
+        ageRange: data.ageRange || null,
+        experienceLevel: data.experienceLevel || null,
+        height: data.height || null,
+        heightUnit: data.heightUnit || 'cm',
+        weight: data.weight || null,
+        weightUnit: data.weightUnit || 'kg',
         sportPreferences: data.sportPreferences || [],
         trainingFor: data.trainingFor || [],
         notificationPreferences: data.notificationPreferences || null,
@@ -177,6 +189,12 @@ export default function ProfilePage() {
         displayName: data.displayName,
         bio: data.bio,
         timezone: data.timezone,
+        ageRange: data.ageRange,
+        experienceLevel: data.experienceLevel,
+        height: data.height ?? undefined,
+        heightUnit: data.heightUnit,
+        weight: data.weight ?? undefined,
+        weightUnit: data.weightUnit,
         sportPreferences: data.sportPreferences,
         trainingFor: data.trainingFor,
         notificationPreferences: data.notificationPreferences,
@@ -402,6 +420,80 @@ export default function ProfilePage() {
                     <SelectTrigger><SelectValue placeholder="Select timezone" /></SelectTrigger>
                     <SelectContent className="max-h-[300px]">{TIMEZONES.map((tz) => <SelectItem key={tz} value={tz}>{formatTimezone(tz)}</SelectItem>)}</SelectContent>
                   </Select>
+                </div>
+              </CardContent>
+            </Card>
+
+            {/* Age, Experience, Body */}
+            <Card>
+              <CardHeader className="pb-3">
+                <CardTitle className="text-base">About You</CardTitle>
+                <CardDescription>Help us personalize your training</CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                <div className="grid grid-cols-2 gap-4">
+                  <div className="space-y-2">
+                    <Label>Age Range</Label>
+                    <Select value={watch('ageRange') || ''} onValueChange={(val) => setValue('ageRange', val, { shouldDirty: true })}>
+                      <SelectTrigger><SelectValue placeholder="Select age" /></SelectTrigger>
+                      <SelectContent>
+                        {AGE_RANGE_OPTIONS.map((opt) => (
+                          <SelectItem key={opt} value={opt}>{opt === 'under-18' ? 'Under 18' : opt === '65+' ? '65+' : opt}</SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+                  <div className="space-y-2">
+                    <Label>Experience Level</Label>
+                    <Select value={watch('experienceLevel') || ''} onValueChange={(val) => setValue('experienceLevel', val, { shouldDirty: true })}>
+                      <SelectTrigger><SelectValue placeholder="Select level" /></SelectTrigger>
+                      <SelectContent>
+                        {EXPERIENCE_LEVEL_OPTIONS.map((opt) => (
+                          <SelectItem key={opt} value={opt}>{opt}</SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+                </div>
+                <div className="grid grid-cols-2 gap-4">
+                  <div className="space-y-2">
+                    <Label>Height</Label>
+                    <div className="flex gap-2">
+                      <Input
+                        type="number"
+                        placeholder={watch('heightUnit') === 'ft' ? 'e.g. 170' : 'e.g. 175'}
+                        value={watch('height') ?? ''}
+                        onChange={(e) => setValue('height', e.target.value ? Number(e.target.value) : null, { shouldDirty: true })}
+                        className="flex-1"
+                      />
+                      <Select value={watch('heightUnit') || 'cm'} onValueChange={(val) => setValue('heightUnit', val as 'cm' | 'ft', { shouldDirty: true })}>
+                        <SelectTrigger className="w-20"><SelectValue /></SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="cm">cm</SelectItem>
+                          <SelectItem value="ft">ft</SelectItem>
+                        </SelectContent>
+                      </Select>
+                    </div>
+                  </div>
+                  <div className="space-y-2">
+                    <Label>Weight</Label>
+                    <div className="flex gap-2">
+                      <Input
+                        type="number"
+                        placeholder={watch('weightUnit') === 'lbs' ? 'e.g. 165' : 'e.g. 75'}
+                        value={watch('weight') ?? ''}
+                        onChange={(e) => setValue('weight', e.target.value ? Number(e.target.value) : null, { shouldDirty: true })}
+                        className="flex-1"
+                      />
+                      <Select value={watch('weightUnit') || 'kg'} onValueChange={(val) => setValue('weightUnit', val as 'kg' | 'lbs', { shouldDirty: true })}>
+                        <SelectTrigger className="w-20"><SelectValue /></SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="kg">kg</SelectItem>
+                          <SelectItem value="lbs">lbs</SelectItem>
+                        </SelectContent>
+                      </Select>
+                    </div>
+                  </div>
                 </div>
               </CardContent>
             </Card>

--- a/src/app/api/auth/strava/authorize/route.ts
+++ b/src/app/api/auth/strava/authorize/route.ts
@@ -34,6 +34,17 @@ export async function GET(request: NextRequest) {
       path: '/',
     });
 
+    // Store redirect origin so callback knows where to send the user
+    const from = request.nextUrl.searchParams.get('from');
+    if (from) {
+      cookieStore.set('strava_oauth_from', from, {
+        httpOnly: true,
+        secure: process.env.NODE_ENV === 'production',
+        maxAge: 600,
+        path: '/',
+      });
+    }
+
     // Build Strava OAuth URL
     const authUrl = new URL('https://www.strava.com/oauth/authorize');
     authUrl.searchParams.append('client_id', clientId);

--- a/src/app/api/auth/strava/callback/route.ts
+++ b/src/app/api/auth/strava/callback/route.ts
@@ -91,12 +91,17 @@ export async function GET(request: NextRequest) {
 
     console.log('✅ Strava tokens saved for user:', username);
 
-    // Clear the cookie
-    cookieStore.delete('strava_oauth_userId');
+    // Determine redirect destination based on where the flow started
+    const from = cookieStore.get('strava_oauth_from')?.value;
+    const redirectPath = from === 'onboarding' ? '/dashboard?strava=connected' : '/settings?strava=connected';
 
-    // Redirect back to settings with success
+    // Clear cookies
+    cookieStore.delete('strava_oauth_userId');
+    cookieStore.delete('strava_oauth_from');
+
+    // Redirect to appropriate page
     return NextResponse.redirect(
-      new URL('/settings?strava=connected', baseUrl)
+      new URL(redirectPath, baseUrl)
     );
   } catch (error: any) {
     console.error('❌ Strava callback error:', error);

--- a/src/app/api/strava/sync/route.ts
+++ b/src/app/api/strava/sync/route.ts
@@ -298,6 +298,7 @@ export async function GET(request: NextRequest) {
     const userId = searchParams.get('userId');
     const checkDuplicates = searchParams.get('checkDuplicates') === 'true';
     const duplicateDecisions = searchParams.get('decisions');
+    const period = searchParams.get('period'); // 'week' | 'month' | 'year' | null
 
     if (!userId) {
       console.error('❌ No userId provided');
@@ -345,12 +346,13 @@ export async function GET(request: NextRequest) {
       console.log('✅ Token refreshed');
     }
 
-    // Fetch activities from the last year in batches
-    console.log('📡 Fetching activities from the last year...');
-    const oneYearAgo = Math.floor(Date.now() / 1000) - (365 * 24 * 60 * 60);
+    // Calculate time range based on period parameter
+    const periodDays = period === 'week' ? 7 : period === 'month' ? 30 : 365;
+    const afterTimestamp = Math.floor(Date.now() / 1000) - (periodDays * 24 * 60 * 60);
+    console.log(`📡 Fetching activities from the last ${period || 'year'} (${periodDays} days)...`);
 
     let activitiesResponse = await fetch(
-      `https://www.strava.com/api/v3/athlete/activities?after=${oneYearAgo}&per_page=200`,
+      `https://www.strava.com/api/v3/athlete/activities?after=${afterTimestamp}&per_page=200`,
       {
         headers: { Authorization: `Bearer ${accessToken}` },
       }
@@ -382,7 +384,7 @@ export async function GET(request: NextRequest) {
       // Retry with new token
       console.log('✅ Token refreshed, retrying request...');
       activitiesResponse = await fetch(
-        `https://www.strava.com/api/v3/athlete/activities?after=${oneYearAgo}&per_page=200`,
+        `https://www.strava.com/api/v3/athlete/activities?after=${afterTimestamp}&per_page=200`,
         {
           headers: { Authorization: `Bearer ${newToken}` },
         }
@@ -430,7 +432,7 @@ export async function GET(request: NextRequest) {
       );
     }
 
-    console.log(`✅ Fetched ${activities.length} activities from last year`);
+    console.log(`✅ Fetched ${activities.length} activities from last ${period || 'year'}`);
 
     // Get existing Strava workout IDs to avoid duplicates
     const existingWorkoutsSnapshot = await adminDb
@@ -737,8 +739,9 @@ export async function GET(request: NextRequest) {
 
     console.log(`✅ Finished: Created ${newWorkoutsCount}, merged ${mergedWorkoutsCount}, skipped ${skippedCount}`);
 
-    // Run Groq dedup after every sync
+    // Run Groq dedup only on full sync (year or no period specified) — skip for partial syncs
     let dedupInfo: any = null;
+    if (!period || period === 'year') {
     try {
       console.log('🔍 Running Groq dedup after sync...');
       const { runDedupPipeline, executeDedupDeletions } = await import('@/lib/groq-dedup');
@@ -755,6 +758,9 @@ export async function GET(request: NextRequest) {
     } catch (dedupErr: any) {
       console.error('⚠️ Dedup pipeline error (non-fatal):', dedupErr.message);
       dedupInfo = { error: dedupErr.message };
+    }
+    } else {
+      console.log(`⏩ Skipping dedup for partial sync (period=${period})`);
     }
 
     // Build response message
@@ -780,6 +786,7 @@ export async function GET(request: NextRequest) {
 
     return NextResponse.json({
       success: true,
+      period: period || 'year',
       newWorkouts: newWorkoutsCount,
       mergedWorkouts: mergedWorkoutsCount,
       totalActivities: activities.length,

--- a/src/hooks/useStravaAutoSync.ts
+++ b/src/hooks/useStravaAutoSync.ts
@@ -7,10 +7,14 @@ import { toast } from 'sonner';
 const SYNC_COOLDOWN_KEY = 'coachtrack_last_strava_sync';
 const COOLDOWN_MS = 5 * 60 * 1000; // 5 minutes between auto-syncs
 
+// Progressive sync phases: fast first, then expand
+const SYNC_PHASES = ['week', 'month', 'year'] as const;
+
 /**
  * Background Strava sync on login / page load.
- * Fires once per session (or after cooldown), silently syncs,
- * and calls onNewWorkouts() if anything came in so the page can refresh.
+ * Syncs progressively: 1 week → 1 month → 1 year.
+ * After each phase that imports workouts, refreshes the page data
+ * so the calendar populates quickly instead of waiting for the full year.
  */
 export function useStravaAutoSync(
   user: User | null,
@@ -20,46 +24,71 @@ export function useStravaAutoSync(
   const [syncResult, setSyncResult] = useState<{ newWorkouts: number; merged: number } | null>(null);
   const hasFired = useRef(false);
 
+  const syncPhase = useCallback(async (userId: string, period: string): Promise<{ newWorkouts: number; merged: number; needsReconnect?: boolean }> => {
+    const res = await fetch(
+      `/api/strava/sync?userId=${userId}&period=${period}`,
+      { headers: { Accept: 'application/json' } },
+    );
+
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({}));
+      if (err.needsReconnect) {
+        return { newWorkouts: 0, merged: 0, needsReconnect: true };
+      }
+      throw new Error(err.error || 'sync failed');
+    }
+
+    const data = await res.json();
+    return {
+      newWorkouts: data.newWorkouts || 0,
+      merged: data.mergedWorkouts || 0,
+    };
+  }, []);
+
   const runSync = useCallback(async (userId: string) => {
     setSyncing(true);
-    try {
-      // Skip duplicate check for auto-sync — just import new stuff
-      const res = await fetch(
-        `/api/strava/sync?userId=${userId}`,
-        { headers: { Accept: 'application/json' } },
-      );
+    let totalNew = 0;
+    let totalMerged = 0;
 
-      if (!res.ok) {
-        const err = await res.json().catch(() => ({}));
-        // Don't toast auth errors on auto-sync — user will see it when they manually sync
-        if (err.needsReconnect) {
+    try {
+      for (const phase of SYNC_PHASES) {
+        console.log(`[auto-sync] phase: ${phase}`);
+
+        const result = await syncPhase(userId, phase);
+
+        if (result.needsReconnect) {
           console.warn('[auto-sync] Strava token expired, needs reconnect');
           return;
         }
-        console.error('[auto-sync] sync failed:', err);
-        return;
+
+        totalNew += result.newWorkouts;
+        totalMerged += result.merged;
+        const phaseTotal = result.newWorkouts + result.merged;
+
+        // Refresh the page after each phase that brought in new data
+        if (phaseTotal > 0) {
+          console.log(`[auto-sync] ${phase}: ${result.newWorkouts} new, ${result.merged} merged — refreshing`);
+          onNewWorkouts?.();
+        } else {
+          console.log(`[auto-sync] ${phase}: no new activities`);
+        }
       }
 
-      const data = await res.json();
-      const total = (data.newWorkouts || 0) + (data.mergedWorkouts || 0);
+      setSyncResult({ newWorkouts: totalNew, merged: totalMerged });
 
-      setSyncResult({ newWorkouts: data.newWorkouts || 0, merged: data.mergedWorkouts || 0 });
-
-      if (total > 0) {
-        // Show a subtle success toast
+      // Show one summary toast after all phases complete
+      const grandTotal = totalNew + totalMerged;
+      if (grandTotal > 0) {
         const parts: string[] = [];
-        if (data.newWorkouts > 0) parts.push(`${data.newWorkouts} new`);
-        if (data.mergedWorkouts > 0) parts.push(`${data.mergedWorkouts} merged`);
-        toast.success(`Strava synced: ${parts.join(', ')} workout${total > 1 ? 's' : ''}`, {
+        if (totalNew > 0) parts.push(`${totalNew} new`);
+        if (totalMerged > 0) parts.push(`${totalMerged} merged`);
+        toast.success(`Strava synced: ${parts.join(', ')} workout${grandTotal > 1 ? 's' : ''}`, {
           icon: '🔄',
           duration: 4000,
         });
-
-        // Tell the page to refresh its data
-        onNewWorkouts?.();
       }
 
-      // Auto-dedup: run after every sync (whether or not new workouts came in)
+      // Auto-dedup: run once after all phases
       try {
         console.log('[auto-sync] running auto-dedup...');
         const dedupRes = await fetch('/api/workouts/auto-dedup', {
@@ -74,7 +103,7 @@ export function useStravaAutoSync(
               icon: '🧹',
               duration: 4000,
             });
-            onNewWorkouts?.(); // refresh again after cleanup
+            onNewWorkouts?.();
           }
         }
       } catch (dedupErr) {
@@ -90,7 +119,7 @@ export function useStravaAutoSync(
     } finally {
       setSyncing(false);
     }
-  }, [onNewWorkouts]);
+  }, [onNewWorkouts, syncPhase]);
 
   useEffect(() => {
     if (hasFired.current) return;
@@ -106,7 +135,7 @@ export function useStravaAutoSync(
     } catch { /* SSR or private browsing */ }
 
     hasFired.current = true;
-    console.log('[auto-sync] firing background Strava sync');
+    console.log('[auto-sync] firing progressive Strava sync');
     runSync(user.username);
   }, [user, runSync]);
 

--- a/src/lib/schemas/profile.ts
+++ b/src/lib/schemas/profile.ts
@@ -24,10 +24,24 @@ export const TRAINING_FOR_OPTIONS = [
   'Other',
 ] as const;
 
+export const AGE_RANGE_OPTIONS = [
+  'under-18', '18-24', '25-34', '35-44', '45-54', '55-64', '65+',
+] as const;
+
+export const EXPERIENCE_LEVEL_OPTIONS = [
+  'Beginner', 'Intermediate', 'Advanced', 'Elite',
+] as const;
+
 export const profileSchema = z.object({
   displayName: z.string().min(2, 'Name must be at least 2 characters').max(50),
   bio: z.string().max(300, 'Bio must be under 300 characters').optional(),
   timezone: z.string().optional(),
+  ageRange: z.string().optional(),
+  experienceLevel: z.string().optional(),
+  height: z.number().positive().optional().nullable(),
+  heightUnit: z.enum(['cm', 'ft']).optional(),
+  weight: z.number().positive().optional().nullable(),
+  weightUnit: z.enum(['kg', 'lbs']).optional(),
   sportPreferences: z.array(z.string()).optional(),
   trainingFor: z.array(z.string()).optional(),
   notificationPreferences: z.object({


### PR DESCRIPTION
## Summary
- Add missing fields (ageRange, experienceLevel, height, weight) to profile edit dialog — completion bar items are now actionable
- Fix post-Strava-connect redirect: onboarding returns to /dashboard instead of /settings
- Progressive Strava sync (week → month → year) for fast calendar population

## Test plan
- [ ] Open profile edit dialog and verify age range, experience, height, weight fields appear and save
- [ ] Complete onboarding with Strava connect — verify redirect goes to /dashboard
- [ ] Connect Strava from settings — verify redirect still goes to /settings
- [ ] Check Strava auto-sync logs show progressive phases (week → month → year)

🤖 Generated with [Claude Code](https://claude.com/claude-code)