### PR TITLE
feat: public athlete profile page at /athlete/[username]

### DIFF
--- a/src/app/(dashboard)/settings/page.tsx
+++ b/src/app/(dashboard)/settings/page.tsx
@@ -8,7 +8,8 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Badge } from '@/components/ui/badge';
 import { toast } from 'sonner';
-import { User, Unlink, Settings, LogOut, Key, CheckCircle2, Loader2, ExternalLink, Copy, Check } from 'lucide-react';
+import { Switch } from '@/components/ui/switch';
+import { User, Unlink, Settings, LogOut, Key, CheckCircle2, Loader2, ExternalLink, Copy, Check, Globe, RefreshCw } from 'lucide-react';
 import { signOut } from '@/lib/firebase/auth';
 import Link from 'next/link';
 import { StravaDuplicateDialog } from '@/components/strava/DuplicateDialog';
@@ -23,6 +24,9 @@ function SettingsContent() {
   const [isDisconnectingStrava, setIsDisconnectingStrava] = useState(false);
   const [isSyncingStrava, setIsSyncingStrava] = useState(false);
   const [copied, setCopied] = useState(false);
+  const [profilePublic, setProfilePublic] = useState(user?.profilePublic !== false);
+  const [profileCopied, setProfileCopied] = useState(false);
+  const [regeneratingTagline, setRegeneratingTagline] = useState(false);
   const [showDuplicateDialog, setShowDuplicateDialog] = useState(false);
   const [stravaDuplicates, setStravaDuplicates] = useState<any[]>([]);
 
@@ -149,6 +153,50 @@ function SettingsContent() {
     handleSyncStrava(decisions);
   };
 
+  const handleTogglePublicProfile = async (checked: boolean) => {
+    if (!user) return;
+    setProfilePublic(checked);
+    try {
+      const { doc, updateDoc } = await import('firebase/firestore');
+      const { getDbInstance } = await import('@/lib/firebase/config');
+      await updateDoc(doc(getDbInstance(), 'users', user.username), { profilePublic: checked });
+      setUser({ ...user, profilePublic: checked });
+      toast.success(checked ? 'Profile is now public' : 'Profile is now private');
+    } catch {
+      setProfilePublic(!checked);
+      toast.error('Failed to update profile visibility');
+    }
+  };
+
+  const handleCopyProfileUrl = () => {
+    if (!user) return;
+    const url = `${window.location.origin}/athlete/${user.username}`;
+    navigator.clipboard.writeText(url);
+    setProfileCopied(true);
+    toast.success('Profile link copied!');
+    setTimeout(() => setProfileCopied(false), 2000);
+  };
+
+  const handleRegenerateTagline = async () => {
+    if (!user) return;
+    setRegeneratingTagline(true);
+    try {
+      const res = await fetch('/api/ai/profile-tagline', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ username: user.username, force: true }),
+      });
+      const data = await res.json();
+      if (data.tagline) {
+        setUser({ ...user, profileTagline: data.tagline });
+        toast.success('New tagline generated!');
+      }
+    } catch {
+      toast.error('Failed to generate tagline');
+    }
+    setRegeneratingTagline(false);
+  };
+
   const handleLogout = async () => { await signOut(); router.push('/login'); };
 
   return (
@@ -230,6 +278,39 @@ function SettingsContent() {
           </CardContent>
         </Card>
       )}
+
+      {/* Public Profile */}
+      <Card>
+        <CardHeader className="pb-3">
+          <CardTitle className="text-base flex items-center gap-2"><Globe className="h-4 w-4 text-primary" />Public Profile</CardTitle>
+          <CardDescription>Share your training stats at /athlete/{user?.username}</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="flex items-center justify-between">
+            <div>
+              <p className="font-medium text-sm">Profile visibility</p>
+              <p className="text-xs text-muted-foreground">When enabled, anyone can view your profile</p>
+            </div>
+            <Switch checked={profilePublic} onCheckedChange={handleTogglePublicProfile} />
+          </div>
+          <div className="flex flex-wrap gap-2">
+            <Button variant="outline" size="sm" onClick={handleCopyProfileUrl}>
+              {profileCopied ? <Check className="h-4 w-4 mr-2" /> : <Copy className="h-4 w-4 mr-2" />}
+              {profileCopied ? 'Copied!' : 'Copy Link'}
+            </Button>
+            <Button variant="outline" size="sm" onClick={handleRegenerateTagline} disabled={regeneratingTagline}>
+              {regeneratingTagline ? <Loader2 className="h-4 w-4 mr-2 animate-spin" /> : <RefreshCw className="h-4 w-4 mr-2" />}
+              {regeneratingTagline ? 'Generating...' : 'New Tagline'}
+            </Button>
+            <Button variant="outline" size="sm" asChild>
+              <Link href={`/athlete/${user?.username}`} target="_blank"><ExternalLink className="h-4 w-4 mr-2" />View Profile</Link>
+            </Button>
+          </div>
+          {user?.profileTagline && (
+            <p className="text-sm text-muted-foreground italic">&ldquo;{user.profileTagline}&rdquo;</p>
+          )}
+        </CardContent>
+      </Card>
 
       {/* Account */}
       <Card>

--- a/src/app/api/ai/profile-tagline/route.ts
+++ b/src/app/api/ai/profile-tagline/route.ts
@@ -1,0 +1,96 @@
+export const dynamic = 'force-dynamic';
+
+import { NextRequest, NextResponse } from 'next/server';
+import { adminDb } from '@/lib/firebase/admin';
+import Groq from 'groq-sdk';
+
+export async function POST(request: NextRequest) {
+  try {
+    const { username, force } = await request.json();
+
+    if (!username) {
+      return NextResponse.json({ error: 'username required' }, { status: 400 });
+    }
+
+    if (!process.env.GROQ_API_KEY) {
+      return NextResponse.json({ error: 'GROQ_API_KEY not configured' }, { status: 500 });
+    }
+
+    const userDoc = await adminDb.collection('users').doc(username).get();
+    if (!userDoc.exists) {
+      return NextResponse.json({ error: 'User not found' }, { status: 404 });
+    }
+
+    const userData = userDoc.data()!;
+
+    // Return cached tagline unless force regeneration
+    if (userData.profileTagline && !force) {
+      return NextResponse.json({ tagline: userData.profileTagline });
+    }
+
+    // Gather context for the tagline
+    const workoutsSnap = await adminDb
+      .collection('users').doc(username).collection('workouts')
+      .where('completed', '==', true)
+      .get();
+
+    const totalWorkouts = workoutsSnap.size;
+    const sports = userData.sportPreferences?.join(', ') || 'various sports';
+    const experience = userData.experienceLevel || 'dedicated';
+    const name = userData.displayName || username;
+
+    // Count by type
+    const typeCounts: Record<string, number> = {};
+    for (const doc of workoutsSnap.docs) {
+      const type = doc.data().type || 'other';
+      typeCounts[type] = (typeCounts[type] || 0) + 1;
+    }
+    const favoriteType = Object.entries(typeCounts).sort((a, b) => b[1] - a[1])[0]?.[0] || null;
+
+    const groq = new Groq({ apiKey: process.env.GROQ_API_KEY.trim() });
+
+    const prompt = `Write a one-sentence motivational tagline for an athlete's public profile page. Max 12 words. Be subtly impressive, not boastful. Make it feel personal and aspirational.
+
+Examples of good taglines:
+- "Chasing sunrises and personal records, one mile at a time."
+- "Where discipline meets the open road."
+- "Building strength through consistency and quiet determination."
+
+Athlete context:
+- Name: ${name}
+- Sports: ${sports}
+- Experience: ${experience}
+- Total completed workouts: ${totalWorkouts}
+${favoriteType ? `- Favorite activity: ${favoriteType}` : ''}
+
+Return ONLY a JSON object: {"tagline": "your tagline here"}`;
+
+    const completion = await groq.chat.completions.create({
+      model: 'llama-3.3-70b-versatile',
+      messages: [
+        { role: 'system', content: 'You are a creative writer for athlete profiles. Return only valid JSON. Be poetic and brief.' },
+        { role: 'user', content: prompt },
+      ],
+      temperature: 0.8,
+      max_tokens: 60,
+      response_format: { type: 'json_object' },
+    });
+
+    const response = completion.choices[0]?.message?.content || '{}';
+    const parsed = JSON.parse(response);
+    const tagline = parsed.tagline && typeof parsed.tagline === 'string'
+      ? parsed.tagline.slice(0, 120)
+      : null;
+
+    if (tagline) {
+      await adminDb.collection('users').doc(username).update({
+        profileTagline: tagline,
+      });
+    }
+
+    return NextResponse.json({ tagline: tagline || null });
+  } catch (error: any) {
+    console.error('Profile tagline error:', error);
+    return NextResponse.json({ error: error.message || 'Failed' }, { status: 500 });
+  }
+}

--- a/src/app/athlete/[username]/AthleteProfileClient.tsx
+++ b/src/app/athlete/[username]/AthleteProfileClient.tsx
@@ -1,0 +1,508 @@
+'use client';
+
+import { useMemo, useEffect, useState } from 'react';
+import Link from 'next/link';
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import {
+  Sparkles, Trophy, Flame, Clock, MapPin, Dumbbell,
+  Activity, UserPlus, LogIn, Lock, Calendar,
+} from 'lucide-react';
+import { format, subMonths, eachDayOfInterval, getDay, startOfWeek } from 'date-fns';
+import { useAuthStore } from '@/lib/stores/authStore';
+import { cn } from '@/lib/utils';
+import {
+  computeSummary,
+  computeTypeDistribution,
+  computeCalendarData,
+  computeInsights,
+  type SummaryStats,
+  type TypeDistribution,
+  type CalendarDay,
+} from '@/lib/analytics';
+import type { Workout, WorkoutType } from '@/types';
+
+// ── Types ──
+
+export interface AthleteProfileData {
+  isPrivate: boolean;
+  displayName: string;
+  username: string;
+  photoURL: string | null;
+  bio: string | null;
+  ageRange: string | null;
+  experienceLevel: string | null;
+  sportPreferences: string[];
+  trainingFor: string[];
+  profileTagline: string | null;
+  stravaConnected: boolean;
+  memberSince: string | null;
+  workouts: SerializedWorkout[];
+  personalRecords: SerializedPR[];
+}
+
+interface SerializedWorkout {
+  id: string;
+  name: string;
+  type: string;
+  date: string;
+  completed: boolean;
+  duration?: number;
+  actualStats?: {
+    distance?: number;
+    duration?: number;
+    calories?: number;
+    avgHeartRate?: number;
+    elevationGain?: number;
+  };
+  strength?: {
+    exercises?: {
+      name: string;
+      sets: number;
+      reps: number;
+      weight?: number;
+      weightUnit?: string;
+    }[];
+  };
+}
+
+interface SerializedPR {
+  id: string;
+  name: string;
+  value: number;
+  unit: string;
+  category: string;
+  date: string;
+}
+
+// ── Constants ──
+
+const TYPE_EMOJI: Record<string, string> = {
+  run: '🏃', bike: '🚴', swim: '🏊', strength: '💪', other: '⚡',
+};
+
+const TYPE_COLORS: Record<string, string> = {
+  swim: '#3b82f6', run: '#22c55e', bike: '#f97316', strength: '#a855f7', other: '#6b7280',
+};
+
+const AGE_LABELS: Record<string, string> = {
+  'under-18': 'Under 18', '18-24': '18–24', '25-34': '25–34',
+  '35-44': '35–44', '45-54': '45–54', '55-64': '55–64', '65+': '65+',
+};
+
+// ── Helpers ──
+
+function formatDistance(km: number): string {
+  if (km >= 1000) return `${(km / 1000).toFixed(1)}k km`;
+  if (km >= 100) return `${Math.round(km)} km`;
+  return `${km.toFixed(1)} km`;
+}
+
+function formatHours(h: number): string {
+  if (h >= 100) return `${Math.round(h)}h`;
+  return `${h.toFixed(1)}h`;
+}
+
+function formatNumber(n: number): string {
+  if (n >= 10000) return `${(n / 1000).toFixed(1)}k`;
+  if (n >= 1000) return n.toLocaleString();
+  return String(Math.round(n));
+}
+
+function getInitials(name: string): string {
+  return name.split(' ').map(w => w[0]).join('').toUpperCase().slice(0, 2);
+}
+
+// ── Component ──
+
+export function AthleteProfileClient({ profile }: { profile: AthleteProfileData }) {
+  const currentUser = useAuthStore((s) => s.user);
+  const isOwnProfile = currentUser?.username === profile.username;
+  const [tagline, setTagline] = useState(profile.profileTagline);
+  const [taglineLoading, setTaglineLoading] = useState(false);
+
+  // Lazy-load tagline if not cached
+  useEffect(() => {
+    if (tagline || profile.isPrivate || profile.workouts.length === 0) return;
+    setTaglineLoading(true);
+    fetch('/api/ai/profile-tagline', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username: profile.username }),
+    })
+      .then(res => res.json())
+      .then(data => { if (data.tagline) setTagline(data.tagline); })
+      .catch(() => {})
+      .finally(() => setTaglineLoading(false));
+  }, [tagline, profile.isPrivate, profile.workouts.length, profile.username]);
+
+  // Cast serialized workouts for analytics functions
+  const workouts = useMemo(() => profile.workouts as unknown as Workout[], [profile.workouts]);
+  const summary = useMemo(() => computeSummary(workouts), [workouts]);
+  const typeDistribution = useMemo(() => computeTypeDistribution(workouts), [workouts]);
+  const calendarData = useMemo(() => computeCalendarData(workouts, 12), [workouts]);
+  const insights = useMemo(() => computeInsights(workouts), [workouts]);
+
+  const recentWorkouts = useMemo(() => {
+    return [...profile.workouts]
+      .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime())
+      .slice(0, 5);
+  }, [profile.workouts]);
+
+  const topPRs = useMemo(() => {
+    return [...profile.personalRecords]
+      .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime())
+      .slice(0, 3);
+  }, [profile.personalRecords]);
+
+  // ── Private profile ──
+  if (profile.isPrivate) {
+    return (
+      <div className="min-h-screen bg-background">
+        <HeaderBar />
+        <div className="max-w-2xl mx-auto px-4 py-20 text-center space-y-6">
+          <div className="inline-flex items-center justify-center w-20 h-20 rounded-full bg-muted">
+            <Lock className="w-8 h-8 text-muted-foreground" />
+          </div>
+          <h1 className="text-2xl font-bold">{profile.displayName}</h1>
+          <p className="text-muted-foreground">This profile is private.</p>
+          <CTABanner isLoggedIn={!!currentUser} />
+        </div>
+      </div>
+    );
+  }
+
+  const hasWorkouts = profile.workouts.length > 0;
+
+  return (
+    <div className="min-h-screen bg-background">
+      <HeaderBar />
+
+      <div className="max-w-3xl mx-auto px-4 py-8 space-y-10">
+        {/* ── Hero ── */}
+        <section className="text-center space-y-4">
+          <Avatar className="w-24 h-24 mx-auto ring-2 ring-primary/20 ring-offset-2 ring-offset-background">
+            {profile.photoURL && <AvatarImage src={profile.photoURL} alt={profile.displayName} />}
+            <AvatarFallback className="text-2xl font-bold bg-gradient-to-br from-primary/20 to-orange-500/20">
+              {getInitials(profile.displayName)}
+            </AvatarFallback>
+          </Avatar>
+
+          <div className="space-y-1">
+            <h1 className="text-3xl sm:text-4xl font-bold tracking-tight">{profile.displayName}</h1>
+            <p className="text-muted-foreground font-mono text-sm">@{profile.username}</p>
+          </div>
+
+          {(tagline || taglineLoading) && (
+            <p className={cn(
+              'text-muted-foreground italic max-w-md mx-auto transition-opacity duration-500',
+              taglineLoading ? 'opacity-0' : 'opacity-100',
+            )}>
+              &ldquo;{tagline}&rdquo;
+            </p>
+          )}
+
+          {profile.bio && (
+            <p className="text-sm text-muted-foreground max-w-lg mx-auto">{profile.bio}</p>
+          )}
+
+          {profile.stravaConnected && (
+            <Badge variant="outline" className="text-xs gap-1">
+              <Activity className="w-3 h-3" /> Strava Connected
+            </Badge>
+          )}
+        </section>
+
+        {/* ── Stats Grid ── */}
+        {hasWorkouts && (
+          <section>
+            <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
+              <StatCard value={String(summary.completedWorkouts)} label="Workouts" icon={<Dumbbell className="w-4 h-4" />} />
+              <StatCard value={formatHours(summary.totalHours)} label="Hours Trained" icon={<Clock className="w-4 h-4" />} />
+              <StatCard value={formatDistance(summary.totalDistanceKm)} label="Distance" icon={<MapPin className="w-4 h-4" />} />
+              <StatCard value={`${summary.currentStreak}d`} label="Current Streak" icon={<Flame className="w-4 h-4" />} accent />
+              {summary.totalCalories > 0 && (
+                <StatCard value={formatNumber(summary.totalCalories)} label="Calories" icon={<Activity className="w-4 h-4" />} />
+              )}
+              <StatCard value={`${Math.round(summary.completionRate)}%`} label="Completion" icon={<Trophy className="w-4 h-4" />} />
+            </div>
+          </section>
+        )}
+
+        {/* ── Personal Info Strip ── */}
+        <section className="flex flex-wrap gap-2 justify-center">
+          {profile.ageRange && AGE_LABELS[profile.ageRange] && (
+            <Badge variant="secondary">{AGE_LABELS[profile.ageRange]}</Badge>
+          )}
+          {profile.experienceLevel && (
+            <Badge variant="secondary">{profile.experienceLevel}</Badge>
+          )}
+          {profile.sportPreferences.map(sport => (
+            <Badge key={sport} variant="outline">{sport}</Badge>
+          ))}
+          {profile.memberSince && (
+            <Badge variant="outline" className="text-xs">
+              Member since {format(new Date(profile.memberSince), 'MMM yyyy')}
+            </Badge>
+          )}
+        </section>
+
+        {/* ── Sport Breakdown ── */}
+        {hasWorkouts && typeDistribution.length > 0 && (
+          <section className="space-y-3">
+            <h2 className="text-sm font-semibold text-muted-foreground uppercase tracking-wider">Training Breakdown</h2>
+            {/* Stacked bar */}
+            <div className="h-3 rounded-full overflow-hidden flex bg-muted">
+              {typeDistribution.map(td => (
+                <div
+                  key={td.type}
+                  style={{ width: `${td.percentage}%`, backgroundColor: td.color }}
+                  className="transition-all duration-500"
+                />
+              ))}
+            </div>
+            <div className="flex flex-wrap gap-4 justify-center">
+              {typeDistribution.map(td => (
+                <div key={td.type} className="flex items-center gap-1.5 text-sm">
+                  <div className="w-2.5 h-2.5 rounded-full" style={{ backgroundColor: td.color }} />
+                  <span className="capitalize">{td.type}</span>
+                  <span className="text-muted-foreground">{td.percentage}%</span>
+                </div>
+              ))}
+            </div>
+          </section>
+        )}
+
+        {/* ── Activity Heatmap ── */}
+        {hasWorkouts && (
+          <section className="space-y-3">
+            <h2 className="text-sm font-semibold text-muted-foreground uppercase tracking-wider">Activity</h2>
+            <ActivityHeatmap data={calendarData} />
+          </section>
+        )}
+
+        {/* ── PR Showcase ── */}
+        {topPRs.length > 0 && (
+          <section className="space-y-3">
+            <h2 className="text-sm font-semibold text-muted-foreground uppercase tracking-wider">Personal Records</h2>
+            <div className="grid gap-3 sm:grid-cols-3">
+              {topPRs.map(pr => (
+                <div key={pr.id} className="rounded-xl border bg-card p-4 space-y-1">
+                  <div className="flex items-center gap-2">
+                    <Trophy className="w-4 h-4 text-amber-500" />
+                    <span className="text-sm font-medium truncate">{pr.name}</span>
+                  </div>
+                  <p className="text-2xl font-bold tabular-nums">
+                    {pr.value} <span className="text-sm font-normal text-muted-foreground">{pr.unit}</span>
+                  </p>
+                  <p className="text-xs text-muted-foreground">{format(new Date(pr.date), 'MMM d, yyyy')}</p>
+                </div>
+              ))}
+            </div>
+          </section>
+        )}
+
+        {/* ── Recent Activity ── */}
+        {recentWorkouts.length > 0 && (
+          <section className="space-y-3">
+            <h2 className="text-sm font-semibold text-muted-foreground uppercase tracking-wider">Recent Workouts</h2>
+            <div className="space-y-2">
+              {recentWorkouts.map(w => (
+                <div key={w.id} className="flex items-center gap-3 rounded-xl border bg-card px-4 py-3">
+                  <span className="text-lg">{TYPE_EMOJI[w.type] || '⚡'}</span>
+                  <div className="flex-1 min-w-0">
+                    <p className="font-medium truncate">{w.name}</p>
+                    <p className="text-xs text-muted-foreground">{format(new Date(w.date), 'MMM d, yyyy')}</p>
+                  </div>
+                  <div className="text-right text-sm text-muted-foreground">
+                    {w.actualStats?.distance
+                      ? `${(w.actualStats.distance / 1000).toFixed(1)} km`
+                      : w.actualStats?.duration
+                        ? `${Math.round(w.actualStats.duration / 60)} min`
+                        : w.duration
+                          ? `${w.duration} min`
+                          : null}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </section>
+        )}
+
+        {/* ── Empty state ── */}
+        {!hasWorkouts && (
+          <div className="text-center py-12 space-y-3">
+            <div className="inline-flex items-center justify-center w-16 h-16 rounded-full bg-muted">
+              <Sparkles className="w-7 h-7 text-muted-foreground" />
+            </div>
+            <p className="text-lg font-medium">Just getting started!</p>
+            <p className="text-sm text-muted-foreground">Check back soon for training stats and achievements.</p>
+          </div>
+        )}
+
+        {/* ── CTA ── */}
+        {!isOwnProfile && <CTABanner isLoggedIn={!!currentUser} />}
+      </div>
+
+      {/* Footer */}
+      <footer className="border-t mt-12 py-6 text-center text-xs text-muted-foreground">
+        Powered by <Link href="/" className="font-semibold hover:text-foreground transition-colors">The Daily Athlete</Link> — Train Harder. Track Smarter.
+      </footer>
+    </div>
+  );
+}
+
+// ── Sub-components ──
+
+function HeaderBar() {
+  return (
+    <header className="border-b">
+      <div className="max-w-3xl mx-auto px-4 py-3 flex items-center gap-2">
+        <Link href="/" className="flex items-center gap-2 hover:opacity-80 transition-opacity">
+          <div className="w-7 h-7 rounded-lg bg-gradient-to-br from-primary to-orange-500 flex items-center justify-center">
+            <Sparkles className="w-4 h-4 text-white" />
+          </div>
+          <span className="font-semibold text-sm">The Daily Athlete</span>
+        </Link>
+      </div>
+    </header>
+  );
+}
+
+function StatCard({ value, label, icon, accent }: {
+  value: string; label: string; icon: React.ReactNode; accent?: boolean;
+}) {
+  return (
+    <div className={cn(
+      'rounded-xl border bg-card p-4 text-center space-y-1 transition-colors',
+      accent && 'border-primary/30 bg-primary/5',
+    )}>
+      <div className="flex justify-center text-muted-foreground">{icon}</div>
+      <p className={cn('text-2xl sm:text-3xl font-bold tabular-nums tracking-tight', accent && 'text-primary')}>
+        {value}
+      </p>
+      <p className="text-xs text-muted-foreground">{label}</p>
+    </div>
+  );
+}
+
+function ActivityHeatmap({ data }: { data: CalendarDay[] }) {
+  // Build weeks grid: 53 columns x 7 rows
+  const weeks: (CalendarDay | null)[][] = [];
+  let currentWeek: (CalendarDay | null)[] = [];
+
+  if (data.length === 0) return null;
+
+  // Pad the first week
+  const firstDayOfWeek = getDay(data[0].date);
+  for (let i = 0; i < firstDayOfWeek; i++) {
+    currentWeek.push(null);
+  }
+
+  for (const day of data) {
+    currentWeek.push(day);
+    if (currentWeek.length === 7) {
+      weeks.push(currentWeek);
+      currentWeek = [];
+    }
+  }
+  if (currentWeek.length > 0) {
+    while (currentWeek.length < 7) currentWeek.push(null);
+    weeks.push(currentWeek);
+  }
+
+  // Month labels
+  const monthLabels: { label: string; weekIdx: number }[] = [];
+  let lastMonth = -1;
+  weeks.forEach((week, weekIdx) => {
+    for (const day of week) {
+      if (day) {
+        const month = day.date.getMonth();
+        if (month !== lastMonth) {
+          monthLabels.push({ label: format(day.date, 'MMM'), weekIdx });
+          lastMonth = month;
+        }
+        break;
+      }
+    }
+  });
+
+  return (
+    <div className="overflow-x-auto">
+      <div className="inline-block">
+        {/* Month labels */}
+        <div className="flex mb-1 text-[10px] text-muted-foreground" style={{ paddingLeft: '18px' }}>
+          {monthLabels.map((m, i) => (
+            <span
+              key={i}
+              className="absolute"
+              style={{ marginLeft: `${m.weekIdx * 14}px` }}
+            >
+              {m.label}
+            </span>
+          ))}
+        </div>
+        <div className="flex gap-[2px] mt-4">
+          {/* Day labels */}
+          <div className="flex flex-col gap-[2px] text-[10px] text-muted-foreground pr-1">
+            {['', 'M', '', 'W', '', 'F', ''].map((d, i) => (
+              <div key={i} className="h-[12px] flex items-center justify-end">{d}</div>
+            ))}
+          </div>
+          {/* Weeks */}
+          {weeks.map((week, wi) => (
+            <div key={wi} className="flex flex-col gap-[2px]">
+              {week.map((day, di) => (
+                <div
+                  key={di}
+                  className={cn(
+                    'w-[12px] h-[12px] rounded-sm',
+                    !day ? 'bg-transparent' :
+                    day.count === 0 ? 'bg-muted/50' :
+                    day.count === 1 ? 'bg-primary/30' :
+                    day.count === 2 ? 'bg-primary/60' :
+                    'bg-primary',
+                  )}
+                  title={day ? `${format(day.date, 'MMM d, yyyy')}: ${day.count} workout${day.count !== 1 ? 's' : ''}` : undefined}
+                />
+              ))}
+            </div>
+          ))}
+        </div>
+        {/* Legend */}
+        <div className="flex items-center gap-1 mt-2 justify-end text-[10px] text-muted-foreground">
+          <span>Less</span>
+          <div className="w-[12px] h-[12px] rounded-sm bg-muted/50" />
+          <div className="w-[12px] h-[12px] rounded-sm bg-primary/30" />
+          <div className="w-[12px] h-[12px] rounded-sm bg-primary/60" />
+          <div className="w-[12px] h-[12px] rounded-sm bg-primary" />
+          <span>More</span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function CTABanner({ isLoggedIn }: { isLoggedIn: boolean }) {
+  if (isLoggedIn) return null;
+
+  return (
+    <section className="rounded-2xl border bg-gradient-to-br from-card to-primary/5 p-8 text-center space-y-4">
+      <div className="space-y-2">
+        <h3 className="text-xl font-bold">Track your training journey</h3>
+        <p className="text-sm text-muted-foreground max-w-md mx-auto">
+          Join The Daily Athlete to sync your workouts, get AI coaching insights, and share your progress.
+        </p>
+      </div>
+      <div className="flex gap-3 justify-center">
+        <Button asChild>
+          <Link href="/register"><UserPlus className="w-4 h-4 mr-2" />Sign Up Free</Link>
+        </Button>
+        <Button variant="outline" asChild>
+          <Link href="/login"><LogIn className="w-4 h-4 mr-2" />Log In</Link>
+        </Button>
+      </div>
+    </section>
+  );
+}

--- a/src/app/athlete/[username]/page.tsx
+++ b/src/app/athlete/[username]/page.tsx
@@ -1,0 +1,184 @@
+import { Metadata } from 'next';
+import { getAdminDb } from '@/lib/firebase/admin';
+import { notFound } from 'next/navigation';
+import { AthleteProfileClient, type AthleteProfileData } from './AthleteProfileClient';
+
+interface AthletePageProps {
+  params: Promise<{ username: string }>;
+}
+
+interface SerializedWorkout {
+  id: string;
+  name: string;
+  type: string;
+  date: string;
+  completed: boolean;
+  duration?: number;
+  actualStats?: {
+    distance?: number;
+    duration?: number;
+    calories?: number;
+    avgHeartRate?: number;
+    elevationGain?: number;
+  };
+  strength?: {
+    exercises?: {
+      name: string;
+      sets: number;
+      reps: number;
+      weight?: number;
+      weightUnit?: string;
+    }[];
+  };
+}
+
+interface SerializedPR {
+  id: string;
+  name: string;
+  value: number;
+  unit: string;
+  category: string;
+  date: string;
+}
+
+async function getAthleteProfile(username: string): Promise<AthleteProfileData | null> {
+  try {
+    const db = getAdminDb();
+    const userDoc = await db.collection('users').doc(username).get();
+    if (!userDoc.exists) return null;
+
+    const userData = userDoc.data()!;
+
+    // Privacy gate
+    if (userData.profilePublic === false) {
+      return {
+        isPrivate: true,
+        displayName: userData.displayName || username,
+        username,
+        photoURL: null,
+        bio: null,
+        ageRange: null,
+        experienceLevel: null,
+        sportPreferences: [],
+        trainingFor: [],
+        profileTagline: null,
+        stravaConnected: false,
+        memberSince: null,
+        workouts: [],
+        personalRecords: [],
+      };
+    }
+
+    // Fetch completed workouts
+    const workoutsSnap = await db
+      .collection('users').doc(username).collection('workouts')
+      .where('completed', '==', true)
+      .get();
+
+    const workouts: SerializedWorkout[] = workoutsSnap.docs.map(doc => {
+      const d = doc.data();
+      return {
+        id: doc.id,
+        name: d.name || 'Workout',
+        type: d.type || 'other',
+        date: d.date?.toDate?.()?.toISOString() || new Date().toISOString(),
+        completed: true,
+        duration: d.duration || undefined,
+        actualStats: d.actualStats ? {
+          distance: d.actualStats.distance || undefined,
+          duration: d.actualStats.duration || undefined,
+          calories: d.actualStats.calories || undefined,
+          avgHeartRate: d.actualStats.avgHeartRate || undefined,
+          elevationGain: d.actualStats.elevationGain || undefined,
+        } : undefined,
+        strength: d.strength?.exercises ? {
+          exercises: d.strength.exercises.map((ex: any) => ({
+            name: ex.name,
+            sets: ex.sets || 0,
+            reps: ex.reps || 0,
+            weight: ex.weight || undefined,
+            weightUnit: ex.weightUnit || undefined,
+          })),
+        } : undefined,
+      };
+    });
+
+    // Fetch personal records
+    const prsSnap = await db.collection('personalRecords')
+      .where('userId', '==', username)
+      .limit(10)
+      .get();
+
+    const personalRecords: SerializedPR[] = prsSnap.docs.map(doc => {
+      const d = doc.data();
+      return {
+        id: doc.id,
+        name: d.name || 'Record',
+        value: d.value || 0,
+        unit: d.unit || '',
+        category: d.category || 'other',
+        date: d.date?.toDate?.()?.toISOString() || new Date().toISOString(),
+      };
+    });
+
+    return {
+      isPrivate: false,
+      displayName: userData.displayName || username,
+      username,
+      photoURL: userData.photoURL || null,
+      bio: userData.bio || null,
+      ageRange: userData.ageRange || null,
+      experienceLevel: userData.experienceLevel || null,
+      sportPreferences: userData.sportPreferences || [],
+      trainingFor: userData.trainingFor || [],
+      profileTagline: userData.profileTagline || null,
+      stravaConnected: !!userData.stravaId,
+      memberSince: userData.createdAt?.toDate?.()?.toISOString() || null,
+      workouts,
+      personalRecords,
+    };
+  } catch (error) {
+    console.error('Error fetching athlete profile:', error);
+    return null;
+  }
+}
+
+export async function generateMetadata({ params }: AthletePageProps): Promise<Metadata> {
+  const { username } = await params;
+  const profile = await getAthleteProfile(username);
+
+  if (!profile || profile.isPrivate) {
+    return { title: 'Athlete Profile | The Daily Athlete' };
+  }
+
+  const title = `${profile.displayName} (@${profile.username}) | The Daily Athlete`;
+  const description = profile.profileTagline
+    || `${profile.displayName} trains on The Daily Athlete. ${profile.workouts.length} workouts and counting.`;
+
+  return {
+    title,
+    description,
+    openGraph: {
+      title,
+      description,
+      type: 'profile',
+      siteName: 'The Daily Athlete',
+    },
+    twitter: {
+      card: 'summary',
+      title,
+      description,
+    },
+  };
+}
+
+export default async function AthletePage({ params }: AthletePageProps) {
+  const { username } = await params;
+  const profile = await getAthleteProfile(username);
+
+  if (!profile) {
+    notFound();
+  }
+
+  return <AthleteProfileClient profile={profile} />;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -51,6 +51,9 @@ export interface User {
   heightUnit?: 'cm' | 'ft';
   weight?: number; // in kg
   weightUnit?: 'kg' | 'lbs';
+  // Public profile
+  profileTagline?: string;    // AI-generated one-liner for public profile
+  profilePublic?: boolean;    // Whether /athlete/username is accessible (default: true)
 }
 
 export interface StravaActivityStats {


### PR DESCRIPTION
## Summary
- Adds public athlete profile page at `/athlete/[username]` — server-rendered with OpenGraph metadata
- Profile shows: avatar, name, AI tagline, stats grid, sport breakdown, 12-month activity heatmap, PR showcase, recent workouts, signup CTA
- AI-generated tagline via Groq, cached in Firestore
- Settings page gains public profile toggle, copy link, regenerate tagline, and view profile buttons

## Test plan
- [ ] Visit `/athlete/{username}` for a user with workouts — full profile renders
- [ ] Visit `/athlete/{username}` for a user with no workouts — graceful empty state
- [ ] Visit `/athlete/nonexistent` — 404 page
- [ ] Toggle profile visibility off in settings — profile shows "private" message
- [ ] Copy profile link from settings — correct URL copied
- [ ] Click "New Tagline" in settings — generates and displays new tagline
- [ ] Check link preview (OpenGraph) when sharing profile URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)