### PR TITLE
refactor: compact athlete profile with pie chart

### DIFF
--- a/src/app/athlete/[username]/AthleteProfileClient.tsx
+++ b/src/app/athlete/[username]/AthleteProfileClient.tsx
@@ -6,22 +6,17 @@ import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import {
-  Sparkles, Trophy, Flame, Clock, MapPin, Dumbbell,
-  Activity, UserPlus, LogIn, Lock, Calendar,
+  Sparkles, Trophy, Clock, MapPin, Dumbbell,
+  Activity, UserPlus, LogIn, Lock,
 } from 'lucide-react';
-import { format, subMonths, eachDayOfInterval, getDay, startOfWeek } from 'date-fns';
+import { format } from 'date-fns';
 import { useAuthStore } from '@/lib/stores/authStore';
 import { cn } from '@/lib/utils';
 import {
   computeSummary,
   computeTypeDistribution,
-  computeCalendarData,
-  computeInsights,
-  type SummaryStats,
-  type TypeDistribution,
-  type CalendarDay,
 } from '@/lib/analytics';
-import type { Workout, WorkoutType } from '@/types';
+import type { Workout } from '@/types';
 
 // ── Types ──
 
@@ -82,13 +77,15 @@ const TYPE_EMOJI: Record<string, string> = {
   run: '🏃', bike: '🚴', swim: '🏊', strength: '💪', other: '⚡',
 };
 
+// Allowed sport types for the sport pills (exclude walk, hike, etc.)
+const FEATURED_SPORTS = new Set(['run', 'bike', 'swim', 'strength']);
+
 const TYPE_COLORS: Record<string, string> = {
   swim: '#3b82f6', run: '#22c55e', bike: '#f97316', strength: '#a855f7', other: '#6b7280',
 };
 
-const AGE_LABELS: Record<string, string> = {
-  'under-18': 'Under 18', '18-24': '18–24', '25-34': '25–34',
-  '35-44': '35–44', '45-54': '45–54', '55-64': '55–64', '65+': '65+',
+const SPORT_LABELS: Record<string, string> = {
+  run: 'Running', bike: 'Cycling', swim: 'Swimming', strength: 'Strength',
 };
 
 // ── Helpers ──
@@ -141,8 +138,24 @@ export function AthleteProfileClient({ profile }: { profile: AthleteProfileData 
   const workouts = useMemo(() => profile.workouts as unknown as Workout[], [profile.workouts]);
   const summary = useMemo(() => computeSummary(workouts), [workouts]);
   const typeDistribution = useMemo(() => computeTypeDistribution(workouts), [workouts]);
-  const calendarData = useMemo(() => computeCalendarData(workouts, 12), [workouts]);
-  const insights = useMemo(() => computeInsights(workouts), [workouts]);
+
+  // Derive active sports from workout history (only featured sports)
+  const activeSports = useMemo(() => {
+    return typeDistribution
+      .filter(td => FEATURED_SPORTS.has(td.type))
+      .map(td => td.type);
+  }, [typeDistribution]);
+
+  // Filter type distribution to featured sports only for pie chart
+  const pieData = useMemo(() => {
+    const featured = typeDistribution.filter(td => FEATURED_SPORTS.has(td.type));
+    const total = featured.reduce((sum, td) => sum + td.count, 0);
+    if (total === 0) return [];
+    return featured.map(td => ({
+      ...td,
+      percentage: Math.round((td.count / total) * 100),
+    }));
+  }, [typeDistribution]);
 
   const recentWorkouts = useMemo(() => {
     return [...profile.workouts]
@@ -179,9 +192,9 @@ export function AthleteProfileClient({ profile }: { profile: AthleteProfileData 
     <div className="min-h-screen bg-background">
       <HeaderBar />
 
-      <div className="max-w-3xl mx-auto px-4 py-8 space-y-10">
+      <div className="max-w-2xl mx-auto px-4 py-6 space-y-6">
         {/* ── Hero ── */}
-        <section className="text-center space-y-4">
+        <section className="text-center space-y-3">
           <Avatar className="w-24 h-24 mx-auto ring-2 ring-primary/20 ring-offset-2 ring-offset-background">
             {profile.photoURL && <AvatarImage src={profile.photoURL} alt={profile.displayName} />}
             <AvatarFallback className="text-2xl font-bold bg-gradient-to-br from-primary/20 to-orange-500/20">
@@ -189,14 +202,14 @@ export function AthleteProfileClient({ profile }: { profile: AthleteProfileData 
             </AvatarFallback>
           </Avatar>
 
-          <div className="space-y-1">
-            <h1 className="text-3xl sm:text-4xl font-bold tracking-tight">{profile.displayName}</h1>
+          <div>
+            <h1 className="text-2xl sm:text-3xl font-bold tracking-tight">{profile.displayName}</h1>
             <p className="text-muted-foreground font-mono text-sm">@{profile.username}</p>
           </div>
 
           {(tagline || taglineLoading) && (
             <p className={cn(
-              'text-muted-foreground italic max-w-md mx-auto transition-opacity duration-500',
+              'text-muted-foreground italic text-sm max-w-sm mx-auto transition-opacity duration-500',
               taglineLoading ? 'opacity-0' : 'opacity-100',
             )}>
               &ldquo;{tagline}&rdquo;
@@ -204,126 +217,104 @@ export function AthleteProfileClient({ profile }: { profile: AthleteProfileData 
           )}
 
           {profile.bio && (
-            <p className="text-sm text-muted-foreground max-w-lg mx-auto">{profile.bio}</p>
+            <p className="text-sm text-muted-foreground max-w-md mx-auto">{profile.bio}</p>
           )}
 
-          {profile.stravaConnected && (
-            <Badge variant="outline" className="text-xs gap-1">
-              <Activity className="w-3 h-3" /> Strava Connected
-            </Badge>
+          {/* Sport pills from workout history */}
+          {activeSports.length > 0 && (
+            <div className="flex flex-wrap gap-1.5 justify-center">
+              {activeSports.map(sport => (
+                <Badge key={sport} variant="secondary" className="text-xs gap-1">
+                  {TYPE_EMOJI[sport]} {SPORT_LABELS[sport] || sport}
+                </Badge>
+              ))}
+              {profile.experienceLevel && (
+                <Badge variant="outline" className="text-xs">{profile.experienceLevel}</Badge>
+              )}
+            </div>
           )}
         </section>
 
         {/* ── Stats Grid ── */}
         {hasWorkouts && (
           <section>
-            <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
-              <StatCard value={String(summary.completedWorkouts)} label="Workouts" icon={<Dumbbell className="w-4 h-4" />} />
-              <StatCard value={formatHours(summary.totalHours)} label="Hours Trained" icon={<Clock className="w-4 h-4" />} />
-              <StatCard value={formatDistance(summary.totalDistanceKm)} label="Distance" icon={<MapPin className="w-4 h-4" />} />
-              <StatCard value={`${summary.currentStreak}d`} label="Current Streak" icon={<Flame className="w-4 h-4" />} accent />
+            <div className="grid grid-cols-2 sm:grid-cols-4 gap-2.5">
+              <StatCard value={String(summary.completedWorkouts)} label="Workouts" icon={<Dumbbell className="w-3.5 h-3.5" />} />
+              <StatCard value={formatHours(summary.totalHours)} label="Hours Trained" icon={<Clock className="w-3.5 h-3.5" />} />
+              <StatCard value={formatDistance(summary.totalDistanceKm)} label="Distance" icon={<MapPin className="w-3.5 h-3.5" />} />
               {summary.totalCalories > 0 && (
-                <StatCard value={formatNumber(summary.totalCalories)} label="Calories" icon={<Activity className="w-4 h-4" />} />
+                <StatCard value={formatNumber(summary.totalCalories)} label="Calories" icon={<Activity className="w-3.5 h-3.5" />} />
               )}
-              <StatCard value={`${Math.round(summary.completionRate)}%`} label="Completion" icon={<Trophy className="w-4 h-4" />} />
             </div>
           </section>
         )}
 
-        {/* ── Personal Info Strip ── */}
-        <section className="flex flex-wrap gap-2 justify-center">
-          {profile.ageRange && AGE_LABELS[profile.ageRange] && (
-            <Badge variant="secondary">{AGE_LABELS[profile.ageRange]}</Badge>
-          )}
-          {profile.experienceLevel && (
-            <Badge variant="secondary">{profile.experienceLevel}</Badge>
-          )}
-          {profile.sportPreferences.map(sport => (
-            <Badge key={sport} variant="outline">{sport}</Badge>
-          ))}
-          {profile.memberSince && (
-            <Badge variant="outline" className="text-xs">
-              Member since {format(new Date(profile.memberSince), 'MMM yyyy')}
-            </Badge>
-          )}
-        </section>
-
-        {/* ── Sport Breakdown ── */}
-        {hasWorkouts && typeDistribution.length > 0 && (
-          <section className="space-y-3">
-            <h2 className="text-sm font-semibold text-muted-foreground uppercase tracking-wider">Training Breakdown</h2>
-            {/* Stacked bar */}
-            <div className="h-3 rounded-full overflow-hidden flex bg-muted">
-              {typeDistribution.map(td => (
-                <div
-                  key={td.type}
-                  style={{ width: `${td.percentage}%`, backgroundColor: td.color }}
-                  className="transition-all duration-500"
-                />
-              ))}
-            </div>
-            <div className="flex flex-wrap gap-4 justify-center">
-              {typeDistribution.map(td => (
-                <div key={td.type} className="flex items-center gap-1.5 text-sm">
-                  <div className="w-2.5 h-2.5 rounded-full" style={{ backgroundColor: td.color }} />
-                  <span className="capitalize">{td.type}</span>
-                  <span className="text-muted-foreground">{td.percentage}%</span>
-                </div>
-              ))}
-            </div>
-          </section>
-        )}
-
-        {/* ── Activity Heatmap ── */}
+        {/* ── Training Breakdown (pie chart) + Recent Workouts side by side on desktop ── */}
         {hasWorkouts && (
-          <section className="space-y-3">
-            <h2 className="text-sm font-semibold text-muted-foreground uppercase tracking-wider">Activity</h2>
-            <ActivityHeatmap data={calendarData} />
+          <section className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            {/* Pie chart */}
+            {pieData.length > 0 && (
+              <div className="rounded-xl border bg-card p-4 space-y-3">
+                <h2 className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">Training Breakdown</h2>
+                <div className="flex items-center justify-center">
+                  <PieChart data={pieData} size={140} />
+                </div>
+                <div className="flex flex-wrap gap-x-4 gap-y-1 justify-center">
+                  {pieData.map(td => (
+                    <div key={td.type} className="flex items-center gap-1.5 text-xs">
+                      <div className="w-2 h-2 rounded-full" style={{ backgroundColor: td.color }} />
+                      <span className="capitalize">{SPORT_LABELS[td.type] || td.type}</span>
+                      <span className="text-muted-foreground">{td.percentage}%</span>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {/* Recent workouts */}
+            {recentWorkouts.length > 0 && (
+              <div className="rounded-xl border bg-card p-4 space-y-3">
+                <h2 className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">Recent Workouts</h2>
+                <div className="space-y-1.5">
+                  {recentWorkouts.map(w => (
+                    <div key={w.id} className="flex items-center gap-2.5 py-1.5">
+                      <span className="text-base">{TYPE_EMOJI[w.type] || '⚡'}</span>
+                      <div className="flex-1 min-w-0">
+                        <p className="text-sm font-medium truncate">{w.name}</p>
+                        <p className="text-[11px] text-muted-foreground">{format(new Date(w.date), 'MMM d')}</p>
+                      </div>
+                      <div className="text-right text-xs text-muted-foreground tabular-nums">
+                        {w.actualStats?.distance
+                          ? `${(w.actualStats.distance / 1000).toFixed(1)} km`
+                          : w.actualStats?.duration
+                            ? `${Math.round(w.actualStats.duration / 60)} min`
+                            : w.duration
+                              ? `${w.duration} min`
+                              : null}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
           </section>
         )}
 
         {/* ── PR Showcase ── */}
         {topPRs.length > 0 && (
           <section className="space-y-3">
-            <h2 className="text-sm font-semibold text-muted-foreground uppercase tracking-wider">Personal Records</h2>
-            <div className="grid gap-3 sm:grid-cols-3">
+            <h2 className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">Personal Records</h2>
+            <div className="grid gap-2.5 sm:grid-cols-3">
               {topPRs.map(pr => (
-                <div key={pr.id} className="rounded-xl border bg-card p-4 space-y-1">
+                <div key={pr.id} className="rounded-xl border bg-card p-3.5 space-y-1">
                   <div className="flex items-center gap-2">
-                    <Trophy className="w-4 h-4 text-amber-500" />
+                    <Trophy className="w-3.5 h-3.5 text-amber-500" />
                     <span className="text-sm font-medium truncate">{pr.name}</span>
                   </div>
-                  <p className="text-2xl font-bold tabular-nums">
-                    {pr.value} <span className="text-sm font-normal text-muted-foreground">{pr.unit}</span>
+                  <p className="text-xl font-bold tabular-nums">
+                    {pr.value} <span className="text-xs font-normal text-muted-foreground">{pr.unit}</span>
                   </p>
-                  <p className="text-xs text-muted-foreground">{format(new Date(pr.date), 'MMM d, yyyy')}</p>
-                </div>
-              ))}
-            </div>
-          </section>
-        )}
-
-        {/* ── Recent Activity ── */}
-        {recentWorkouts.length > 0 && (
-          <section className="space-y-3">
-            <h2 className="text-sm font-semibold text-muted-foreground uppercase tracking-wider">Recent Workouts</h2>
-            <div className="space-y-2">
-              {recentWorkouts.map(w => (
-                <div key={w.id} className="flex items-center gap-3 rounded-xl border bg-card px-4 py-3">
-                  <span className="text-lg">{TYPE_EMOJI[w.type] || '⚡'}</span>
-                  <div className="flex-1 min-w-0">
-                    <p className="font-medium truncate">{w.name}</p>
-                    <p className="text-xs text-muted-foreground">{format(new Date(w.date), 'MMM d, yyyy')}</p>
-                  </div>
-                  <div className="text-right text-sm text-muted-foreground">
-                    {w.actualStats?.distance
-                      ? `${(w.actualStats.distance / 1000).toFixed(1)} km`
-                      : w.actualStats?.duration
-                        ? `${Math.round(w.actualStats.duration / 60)} min`
-                        : w.duration
-                          ? `${w.duration} min`
-                          : null}
-                  </div>
+                  <p className="text-[11px] text-muted-foreground">{format(new Date(pr.date), 'MMM d, yyyy')}</p>
                 </div>
               ))}
             </div>
@@ -332,12 +323,12 @@ export function AthleteProfileClient({ profile }: { profile: AthleteProfileData 
 
         {/* ── Empty state ── */}
         {!hasWorkouts && (
-          <div className="text-center py-12 space-y-3">
-            <div className="inline-flex items-center justify-center w-16 h-16 rounded-full bg-muted">
-              <Sparkles className="w-7 h-7 text-muted-foreground" />
+          <div className="text-center py-10 space-y-2">
+            <div className="inline-flex items-center justify-center w-14 h-14 rounded-full bg-muted">
+              <Sparkles className="w-6 h-6 text-muted-foreground" />
             </div>
-            <p className="text-lg font-medium">Just getting started!</p>
-            <p className="text-sm text-muted-foreground">Check back soon for training stats and achievements.</p>
+            <p className="text-base font-medium">Just getting started!</p>
+            <p className="text-sm text-muted-foreground">Check back soon for training stats.</p>
           </div>
         )}
 
@@ -346,8 +337,8 @@ export function AthleteProfileClient({ profile }: { profile: AthleteProfileData 
       </div>
 
       {/* Footer */}
-      <footer className="border-t mt-12 py-6 text-center text-xs text-muted-foreground">
-        Powered by <Link href="/" className="font-semibold hover:text-foreground transition-colors">The Daily Athlete</Link> — Train Harder. Track Smarter.
+      <footer className="border-t mt-8 py-4 text-center text-xs text-muted-foreground">
+        Powered by <Link href="/" className="font-semibold hover:text-foreground transition-colors">The Daily Athlete</Link>
       </footer>
     </div>
   );
@@ -358,7 +349,7 @@ export function AthleteProfileClient({ profile }: { profile: AthleteProfileData 
 function HeaderBar() {
   return (
     <header className="border-b">
-      <div className="max-w-3xl mx-auto px-4 py-3 flex items-center gap-2">
+      <div className="max-w-2xl mx-auto px-4 py-3 flex items-center gap-2">
         <Link href="/" className="flex items-center gap-2 hover:opacity-80 transition-opacity">
           <div className="w-7 h-7 rounded-lg bg-gradient-to-br from-primary to-orange-500 flex items-center justify-center">
             <Sparkles className="w-4 h-4 text-white" />
@@ -370,117 +361,69 @@ function HeaderBar() {
   );
 }
 
-function StatCard({ value, label, icon, accent }: {
-  value: string; label: string; icon: React.ReactNode; accent?: boolean;
+function StatCard({ value, label, icon }: {
+  value: string; label: string; icon: React.ReactNode;
 }) {
   return (
-    <div className={cn(
-      'rounded-xl border bg-card p-4 text-center space-y-1 transition-colors',
-      accent && 'border-primary/30 bg-primary/5',
-    )}>
+    <div className="rounded-xl border bg-card p-3 text-center space-y-0.5">
       <div className="flex justify-center text-muted-foreground">{icon}</div>
-      <p className={cn('text-2xl sm:text-3xl font-bold tabular-nums tracking-tight', accent && 'text-primary')}>
-        {value}
-      </p>
-      <p className="text-xs text-muted-foreground">{label}</p>
+      <p className="text-xl sm:text-2xl font-bold tabular-nums tracking-tight">{value}</p>
+      <p className="text-[11px] text-muted-foreground">{label}</p>
     </div>
   );
 }
 
-function ActivityHeatmap({ data }: { data: CalendarDay[] }) {
-  // Build weeks grid: 53 columns x 7 rows
-  const weeks: (CalendarDay | null)[][] = [];
-  let currentWeek: (CalendarDay | null)[] = [];
+function PieChart({ data, size }: { data: { type: string; percentage: number; color: string; count: number }[]; size: number }) {
+  const radius = size / 2;
+  const innerRadius = radius * 0.55; // donut hole
+  const center = radius;
 
-  if (data.length === 0) return null;
+  // Build SVG arc paths
+  let cumulativePercent = 0;
+  const slices = data.map(d => {
+    const startAngle = cumulativePercent * 3.6 * (Math.PI / 180); // percent → degrees → radians
+    cumulativePercent += d.percentage;
+    const endAngle = cumulativePercent * 3.6 * (Math.PI / 180);
 
-  // Pad the first week
-  const firstDayOfWeek = getDay(data[0].date);
-  for (let i = 0; i < firstDayOfWeek; i++) {
-    currentWeek.push(null);
-  }
+    const x1 = center + radius * Math.sin(startAngle);
+    const y1 = center - radius * Math.cos(startAngle);
+    const x2 = center + radius * Math.sin(endAngle);
+    const y2 = center - radius * Math.cos(endAngle);
 
-  for (const day of data) {
-    currentWeek.push(day);
-    if (currentWeek.length === 7) {
-      weeks.push(currentWeek);
-      currentWeek = [];
-    }
-  }
-  if (currentWeek.length > 0) {
-    while (currentWeek.length < 7) currentWeek.push(null);
-    weeks.push(currentWeek);
-  }
+    const ix1 = center + innerRadius * Math.sin(startAngle);
+    const iy1 = center - innerRadius * Math.cos(startAngle);
+    const ix2 = center + innerRadius * Math.sin(endAngle);
+    const iy2 = center - innerRadius * Math.cos(endAngle);
 
-  // Month labels
-  const monthLabels: { label: string; weekIdx: number }[] = [];
-  let lastMonth = -1;
-  weeks.forEach((week, weekIdx) => {
-    for (const day of week) {
-      if (day) {
-        const month = day.date.getMonth();
-        if (month !== lastMonth) {
-          monthLabels.push({ label: format(day.date, 'MMM'), weekIdx });
-          lastMonth = month;
-        }
-        break;
-      }
-    }
+    const largeArc = d.percentage > 50 ? 1 : 0;
+
+    const path = [
+      `M ${x1} ${y1}`,
+      `A ${radius} ${radius} 0 ${largeArc} 1 ${x2} ${y2}`,
+      `L ${ix2} ${iy2}`,
+      `A ${innerRadius} ${innerRadius} 0 ${largeArc} 0 ${ix1} ${iy1}`,
+      'Z',
+    ].join(' ');
+
+    return { ...d, path };
   });
 
+  // Total workouts for center label
+  const total = data.reduce((sum, d) => sum + d.count, 0);
+
   return (
-    <div className="overflow-x-auto">
-      <div className="inline-block">
-        {/* Month labels */}
-        <div className="flex mb-1 text-[10px] text-muted-foreground" style={{ paddingLeft: '18px' }}>
-          {monthLabels.map((m, i) => (
-            <span
-              key={i}
-              className="absolute"
-              style={{ marginLeft: `${m.weekIdx * 14}px` }}
-            >
-              {m.label}
-            </span>
-          ))}
-        </div>
-        <div className="flex gap-[2px] mt-4">
-          {/* Day labels */}
-          <div className="flex flex-col gap-[2px] text-[10px] text-muted-foreground pr-1">
-            {['', 'M', '', 'W', '', 'F', ''].map((d, i) => (
-              <div key={i} className="h-[12px] flex items-center justify-end">{d}</div>
-            ))}
-          </div>
-          {/* Weeks */}
-          {weeks.map((week, wi) => (
-            <div key={wi} className="flex flex-col gap-[2px]">
-              {week.map((day, di) => (
-                <div
-                  key={di}
-                  className={cn(
-                    'w-[12px] h-[12px] rounded-sm',
-                    !day ? 'bg-transparent' :
-                    day.count === 0 ? 'bg-muted/50' :
-                    day.count === 1 ? 'bg-primary/30' :
-                    day.count === 2 ? 'bg-primary/60' :
-                    'bg-primary',
-                  )}
-                  title={day ? `${format(day.date, 'MMM d, yyyy')}: ${day.count} workout${day.count !== 1 ? 's' : ''}` : undefined}
-                />
-              ))}
-            </div>
-          ))}
-        </div>
-        {/* Legend */}
-        <div className="flex items-center gap-1 mt-2 justify-end text-[10px] text-muted-foreground">
-          <span>Less</span>
-          <div className="w-[12px] h-[12px] rounded-sm bg-muted/50" />
-          <div className="w-[12px] h-[12px] rounded-sm bg-primary/30" />
-          <div className="w-[12px] h-[12px] rounded-sm bg-primary/60" />
-          <div className="w-[12px] h-[12px] rounded-sm bg-primary" />
-          <span>More</span>
-        </div>
-      </div>
-    </div>
+    <svg width={size} height={size} viewBox={`0 0 ${size} ${size}`}>
+      {slices.map((s, i) => (
+        <path key={i} d={s.path} fill={s.color} opacity={0.85} />
+      ))}
+      {/* Center text */}
+      <text x={center} y={center - 6} textAnchor="middle" className="fill-foreground text-xl font-bold" fontSize="22">
+        {total}
+      </text>
+      <text x={center} y={center + 12} textAnchor="middle" className="fill-muted-foreground" fontSize="10">
+        workouts
+      </text>
+    </svg>
   );
 }
 
@@ -488,19 +431,19 @@ function CTABanner({ isLoggedIn }: { isLoggedIn: boolean }) {
   if (isLoggedIn) return null;
 
   return (
-    <section className="rounded-2xl border bg-gradient-to-br from-card to-primary/5 p-8 text-center space-y-4">
-      <div className="space-y-2">
-        <h3 className="text-xl font-bold">Track your training journey</h3>
-        <p className="text-sm text-muted-foreground max-w-md mx-auto">
-          Join The Daily Athlete to sync your workouts, get AI coaching insights, and share your progress.
+    <section className="rounded-2xl border bg-gradient-to-br from-card to-primary/5 p-6 text-center space-y-3">
+      <div className="space-y-1">
+        <h3 className="text-lg font-bold">Track your training journey</h3>
+        <p className="text-sm text-muted-foreground max-w-sm mx-auto">
+          Join The Daily Athlete to sync your workouts and share your progress.
         </p>
       </div>
       <div className="flex gap-3 justify-center">
-        <Button asChild>
-          <Link href="/register"><UserPlus className="w-4 h-4 mr-2" />Sign Up Free</Link>
+        <Button size="sm" asChild>
+          <Link href="/register"><UserPlus className="w-4 h-4 mr-1.5" />Sign Up Free</Link>
         </Button>
-        <Button variant="outline" asChild>
-          <Link href="/login"><LogIn className="w-4 h-4 mr-2" />Log In</Link>
+        <Button variant="outline" size="sm" asChild>
+          <Link href="/login"><LogIn className="w-4 h-4 mr-1.5" />Log In</Link>
         </Button>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- Remove clutter: age range, member since, streak, completion %, Strava badge, activity heatmap
- Training breakdown: stacked bar → donut pie chart (SVG)
- Pie chart + recent workouts side by side on desktop, stacked on mobile
- Sport pills from workout history (run/cycle/swim/strength only, no walk/hike)
- Tighter spacing throughout, max-width 2xl

## Test plan
- [ ] Visit `/athlete/{username}` — compact layout, no excess whitespace
- [ ] Pie chart renders correctly with sport colors
- [ ] On mobile: pie chart and recent workouts stack vertically
- [ ] On desktop: side by side

🤖 Generated with [Claude Code](https://claude.com/claude-code)