### PR TITLE
feat: progressive Strava sync on calendar after onboarding

### DIFF
--- a/src/app/(dashboard)/calendar/page.tsx
+++ b/src/app/(dashboard)/calendar/page.tsx
@@ -1,9 +1,11 @@
 'use client';
 
-import { useState, useEffect, useMemo } from 'react';
+import { useState, useEffect, useMemo, useCallback } from 'react';
 import { useAuthStore } from '@/lib/stores/authStore';
+import { useSearchParams } from 'next/navigation';
 import { getUserWorkouts, completeWorkout, getCoachStudents } from '@/lib/firebase/firestore';
 import { Workout } from '@/types';
+import { useStravaAutoSync } from '@/hooks/useStravaAutoSync';
 import {
   ChevronLeft,
   ChevronRight,
@@ -13,6 +15,7 @@ import {
   Send,
   Route,
   Timer,
+  Loader2,
 } from 'lucide-react';
 import {
   format,
@@ -105,6 +108,7 @@ function formatDurLong(mins: number): string {
 
 export default function CalendarPage() {
   const user = useAuthStore((s) => s.user);
+  const searchParams = useSearchParams();
   const [workouts, setWorkouts] = useState<Workout[]>([]);
   const [loading, setLoading] = useState(true);
   const [weekStart, setWeekStart] = useState(() => startOfWeek(new Date(), { weekStartsOn: 1 }));
@@ -113,6 +117,24 @@ export default function CalendarPage() {
   const [athletes, setAthletes] = useState<{ uid: string; displayName: string }[]>([]);
   const [selectedAthlete, setSelectedAthlete] = useState<string>('all');
   const isCoach = user?.role === 'coach';
+
+  // Fresh from onboarding Strava connect — skip cooldown, run progressive sync
+  const fromStrava = searchParams.get('strava') === 'connected';
+
+  // Refresh workouts from Firestore (called after each sync phase)
+  const refreshWorkouts = useCallback(async () => {
+    if (!user) return;
+    const data = await getUserWorkouts(user.username, user.role);
+    setWorkouts(data);
+    setLoading(false);
+  }, [user]);
+
+  // Progressive Strava sync — runs on the calendar when arriving from onboarding
+  const { syncing, syncPhaseLabel } = useStravaAutoSync(
+    fromStrava ? user : null,
+    refreshWorkouts,
+    fromStrava, // skipCooldown
+  );
 
   useEffect(() => {
     if (!user) return;
@@ -357,6 +379,16 @@ export default function CalendarPage() {
             })}
         </div>
       </div>
+
+      {/* Strava Sync Indicator */}
+      {syncing && (
+        <div className="flex items-center gap-3 px-4 py-2.5 rounded-xl border border-orange-500/20 bg-orange-500/5">
+          <Loader2 className="h-4 w-4 animate-spin text-orange-500 shrink-0" />
+          <p className="text-sm text-orange-600 dark:text-orange-400">
+            Syncing Strava workouts{syncPhaseLabel ? ` — ${syncPhaseLabel}` : ''}...
+          </p>
+        </div>
+      )}
 
       {/* Full-width Weekly Grid */}
       <div className="flex gap-0 border rounded-2xl overflow-hidden" style={{ height: 'calc(100vh - 210px)' }}>

--- a/src/app/(dashboard)/dashboard/page.tsx
+++ b/src/app/(dashboard)/dashboard/page.tsx
@@ -1,8 +1,7 @@
 'use client';
 
-import { useEffect, useState, useMemo, useCallback, useRef } from 'react';
+import { useEffect, useState, useMemo, useCallback } from 'react';
 import { useAuthStore } from '@/lib/stores/authStore';
-import { useRouter, useSearchParams } from 'next/navigation';
 import { getUserWorkouts } from '@/lib/firebase/firestore';
 import { Workout } from '@/types';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
@@ -64,15 +63,9 @@ function calculateStreak(workouts: Workout[]): number {
 
 export default function DashboardPage() {
   const user = useAuthStore((state) => state.user);
-  const router = useRouter();
   const [workouts, setWorkouts] = useState<Workout[]>([]);
   const [loading, setLoading] = useState(true);
   const [ready, setReady] = useState(false);
-  const searchParams = useSearchParams();
-  const redirectedRef = useRef(false);
-
-  // Detect if arriving from onboarding Strava connect
-  const fromOnboarding = searchParams.get('strava') === 'connected';
 
   const greeting = useMemo(() => {
     const hour = new Date().getHours();
@@ -88,16 +81,8 @@ export default function DashboardPage() {
     setWorkouts(workoutData);
   }, [user]);
 
-  // After first sync phase (week data), redirect to calendar so user sees recent workouts
-  // The async sync function continues running in the background (month/year phases)
-  const handleFirstPhaseComplete = useCallback(() => {
-    if (!fromOnboarding || redirectedRef.current) return;
-    redirectedRef.current = true;
-    router.push('/calendar');
-  }, [fromOnboarding, router]);
-
-  // Auto-sync Strava in background on login
-  useStravaAutoSync(user, refreshWorkouts, fromOnboarding ? handleFirstPhaseComplete : undefined);
+  // Auto-sync Strava in background on regular login
+  useStravaAutoSync(user, refreshWorkouts);
 
   useEffect(() => {
     async function loadData() {

--- a/src/app/api/auth/strava/callback/route.ts
+++ b/src/app/api/auth/strava/callback/route.ts
@@ -93,7 +93,7 @@ export async function GET(request: NextRequest) {
 
     // Determine redirect destination based on where the flow started
     const from = cookieStore.get('strava_oauth_from')?.value;
-    const redirectPath = from === 'onboarding' ? '/dashboard?strava=connected' : '/settings?strava=connected';
+    const redirectPath = from === 'onboarding' ? '/calendar?strava=connected' : '/settings?strava=connected';
 
     // Clear cookies
     cookieStore.delete('strava_oauth_userId');

--- a/src/app/api/strava/sync/route.ts
+++ b/src/app/api/strava/sync/route.ts
@@ -347,7 +347,10 @@ export async function GET(request: NextRequest) {
     }
 
     // Calculate time range based on period parameter
-    const periodDays = period === 'week' ? 7 : period === 'month' ? 30 : 365;
+    const PERIOD_DAYS: Record<string, number> = {
+      '2days': 2, 'week': 7, 'month': 30, '2months': 60, '6months': 180, 'year': 365,
+    };
+    const periodDays = (period && PERIOD_DAYS[period]) || 365;
     const afterTimestamp = Math.floor(Date.now() / 1000) - (periodDays * 24 * 60 * 60);
     console.log(`📡 Fetching activities from the last ${period || 'year'} (${periodDays} days)...`);
 

--- a/src/hooks/useStravaAutoSync.ts
+++ b/src/hooks/useStravaAutoSync.ts
@@ -7,25 +7,36 @@ import { toast } from 'sonner';
 const SYNC_COOLDOWN_KEY = 'coachtrack_last_strava_sync';
 const COOLDOWN_MS = 5 * 60 * 1000; // 5 minutes between auto-syncs
 
-// Progressive sync phases: fast first, then expand
-const SYNC_PHASES = ['week', 'month', 'year'] as const;
+// Progressive sync phases: most recent first, then expand
+const SYNC_PHASES = ['2days', 'week', 'month', '2months', '6months', 'year'] as const;
+
+const PHASE_LABELS: Record<string, string> = {
+  '2days': 'last 2 days',
+  'week': 'last week',
+  'month': 'last 30 days',
+  '2months': 'last 60 days',
+  '6months': 'last 6 months',
+  'year': 'last year',
+};
 
 /**
  * Background Strava sync on login / page load.
- * Syncs progressively: 1 week → 1 month → 1 year.
+ * Syncs progressively: 2 days → 1 week → 1 month → 2 months → 6 months → 1 year.
  * After each phase that imports workouts, refreshes the page data
  * so the calendar populates quickly instead of waiting for the full year.
  */
 export function useStravaAutoSync(
   user: User | null,
   onNewWorkouts?: () => void,
-  onFirstPhaseComplete?: () => void,
+  /** Skip cooldown check (e.g. fresh onboarding) */
+  skipCooldown?: boolean,
 ) {
   const [syncing, setSyncing] = useState(false);
+  const [syncPhaseLabel, setSyncPhaseLabel] = useState<string | null>(null);
   const [syncResult, setSyncResult] = useState<{ newWorkouts: number; merged: number } | null>(null);
   const hasFired = useRef(false);
 
-  const syncPhase = useCallback(async (userId: string, period: string): Promise<{ newWorkouts: number; merged: number; needsReconnect?: boolean }> => {
+  const fetchPhase = useCallback(async (userId: string, period: string): Promise<{ newWorkouts: number; merged: number; needsReconnect?: boolean }> => {
     const res = await fetch(
       `/api/strava/sync?userId=${userId}&period=${period}`,
       { headers: { Accept: 'application/json' } },
@@ -50,13 +61,13 @@ export function useStravaAutoSync(
     setSyncing(true);
     let totalNew = 0;
     let totalMerged = 0;
-    let firstPhaseNotified = false;
 
     try {
       for (const phase of SYNC_PHASES) {
         console.log(`[auto-sync] phase: ${phase}`);
+        setSyncPhaseLabel(PHASE_LABELS[phase] || phase);
 
-        const result = await syncPhase(userId, phase);
+        const result = await fetchPhase(userId, phase);
 
         if (result.needsReconnect) {
           console.warn('[auto-sync] Strava token expired, needs reconnect');
@@ -73,12 +84,6 @@ export function useStravaAutoSync(
           onNewWorkouts?.();
         } else {
           console.log(`[auto-sync] ${phase}: no new activities`);
-        }
-
-        // After first phase completes, notify caller (e.g. to redirect to calendar)
-        if (!firstPhaseNotified && phase === 'week') {
-          firstPhaseNotified = true;
-          onFirstPhaseComplete?.();
         }
       }
 
@@ -126,26 +131,29 @@ export function useStravaAutoSync(
       console.error('[auto-sync] unexpected error:', err);
     } finally {
       setSyncing(false);
+      setSyncPhaseLabel(null);
     }
-  }, [onNewWorkouts, onFirstPhaseComplete, syncPhase]);
+  }, [onNewWorkouts, fetchPhase]);
 
   useEffect(() => {
     if (hasFired.current) return;
     if (!user?.stravaAccessToken) return;
 
-    // Cooldown check — don't spam Strava
-    try {
-      const last = sessionStorage.getItem(SYNC_COOLDOWN_KEY);
-      if (last && Date.now() - Number(last) < COOLDOWN_MS) {
-        console.log('[auto-sync] skipped — cooldown active');
-        return;
-      }
-    } catch { /* SSR or private browsing */ }
+    // Cooldown check — don't spam Strava (skip for fresh onboarding)
+    if (!skipCooldown) {
+      try {
+        const last = sessionStorage.getItem(SYNC_COOLDOWN_KEY);
+        if (last && Date.now() - Number(last) < COOLDOWN_MS) {
+          console.log('[auto-sync] skipped — cooldown active');
+          return;
+        }
+      } catch { /* SSR or private browsing */ }
+    }
 
     hasFired.current = true;
     console.log('[auto-sync] firing progressive Strava sync');
     runSync(user.username);
-  }, [user, runSync]);
+  }, [user, runSync, skipCooldown]);
 
-  return { syncing, syncResult };
+  return { syncing, syncPhaseLabel, syncResult };
 }


### PR DESCRIPTION
## Summary
- Onboarding Strava connect now redirects to `/calendar` instead of `/dashboard`
- Granular sync phases (2days → week → month → 2months → 6months → year) so recent workouts appear instantly
- Live sync indicator banner on calendar shows current phase
- Cooldown skipped for fresh onboarding

## Test plan
- [ ] Connect Strava during onboarding → lands on calendar, not dashboard
- [ ] Workouts appear on calendar within seconds (2-day phase)
- [ ] Orange sync banner visible and updates phase labels
- [ ] Banner disappears when sync completes
- [ ] Regular dashboard login still syncs normally with cooldown

🤖 Generated with [Claude Code](https://claude.com/claude-code)