### PR TITLE
feat: calendar redesign — monthly grid + mobile week strip

### DIFF
--- a/src/app/(dashboard)/calendar/page.tsx
+++ b/src/app/(dashboard)/calendar/page.tsx
@@ -6,122 +6,58 @@ import { useSearchParams } from 'next/navigation';
 import { getUserWorkouts, completeWorkout, getCoachStudents } from '@/lib/firebase/firestore';
 import { Workout } from '@/types';
 import { useStravaAutoSync } from '@/hooks/useStravaAutoSync';
-import {
-  ChevronLeft,
-  ChevronRight,
-  Download,
-  CheckCircle2,
-  Circle,
-  Send,
-  Route,
-  Timer,
-  Loader2,
-} from 'lucide-react';
+import { Loader2 } from 'lucide-react';
 import {
   format,
   startOfWeek,
+  addDays,
   addWeeks,
   subWeeks,
-  eachDayOfInterval,
+  startOfMonth,
+  endOfMonth,
   isSameDay,
-  isToday,
-  isPast,
-  addDays,
 } from 'date-fns';
-import Link from 'next/link';
 import { toast } from 'sonner';
-import { cn } from '@/lib/utils';
 
-const TYPE_CONFIG: Record<string, { emoji: string; color: string; border: string; bg: string }> = {
-  run: { emoji: '🏃', color: 'text-red-500', border: 'border-l-red-500', bg: 'bg-red-500/8' },
-  bike: { emoji: '🚴', color: 'text-amber-500', border: 'border-l-amber-500', bg: 'bg-amber-500/8' },
-  swim: { emoji: '🏊', color: 'text-cyan-500', border: 'border-l-cyan-500', bg: 'bg-cyan-500/8' },
-  strength: { emoji: '💪', color: 'text-purple-500', border: 'border-l-purple-500', bg: 'bg-purple-500/8' },
-  other: { emoji: '📋', color: 'text-gray-400', border: 'border-l-gray-400', bg: 'bg-gray-500/8' },
-};
-
-function getTypeData(w: Workout) {
-  const d: Record<string, string> = {};
-  
-  // Primary stat (distance or sets)
-  if (w.type === 'run' && w.run) {
-    d.primary = w.run.distance ? `${w.run.distance} ${w.run.distanceUnit || 'km'}` : '--';
-    d.primaryLabel = 'DISTANCE';
-    d.time = w.run.time ? formatDur(w.run.time) : (w.duration ? formatDur(w.duration) : '0:00');
-    d.hr = w.run.avgHeartRate ? `${w.run.avgHeartRate}` : '--';
-    d.hrLabel = 'AVG HR';
-    d.stat4 = w.run.elevationGain ? `${w.run.elevationGain}m` : (w.run.pace ? `${w.run.pace}` : '--');
-    d.stat4Label = w.run.elevationGain ? 'ELEV' : 'PACE';
-  } else if (w.type === 'bike' && w.bike) {
-    d.primary = w.bike.distance ? `${w.bike.distance} ${w.bike.distanceUnit || 'km'}` : '--';
-    d.primaryLabel = 'DISTANCE';
-    d.time = w.bike.time ? formatDur(w.bike.time) : (w.duration ? formatDur(w.duration) : '0:00');
-    d.hr = w.bike.avgHeartRate ? `${w.bike.avgHeartRate}` : '--';
-    d.hrLabel = 'AVG HR';
-    d.stat4 = w.bike.elevationGain ? `${w.bike.elevationGain}m` : '--';
-    d.stat4Label = 'ELEV';
-  } else if (w.type === 'swim' && w.swim) {
-    d.primary = w.swim.distance ? `${w.swim.distance} ${w.swim.distanceUnit || 'm'}` : '--';
-    d.primaryLabel = 'DISTANCE';
-    d.time = w.swim.time ? formatDur(w.swim.time) : (w.duration ? formatDur(w.duration) : '0:00');
-    d.hr = '--';
-    d.hrLabel = 'AVG HR';
-    d.stat4 = '--';
-    d.stat4Label = 'PACE';
-  } else if (w.type === 'strength' && w.strength) {
-    const exCount = w.strength.exercises?.length || 0;
-    const totalSets = w.strength.exercises?.reduce((sum, ex) => sum + (ex.sets || 0), 0) || 0;
-    d.primary = totalSets > 0 ? `${totalSets} Sets` : (exCount > 0 ? `${exCount} Ex` : '--');
-    d.primaryLabel = totalSets > 0 ? 'TOTAL SETS' : 'EXERCISES';
-    d.time = w.duration ? formatDur(w.duration) : '0:00';
-    d.hr = '--';
-    d.hrLabel = 'AVG HR';
-    d.stat4 = '--';
-    d.stat4Label = 'CALORIES';
-  } else {
-    d.primary = '--';
-    d.primaryLabel = 'DISTANCE';
-    d.time = w.duration ? formatDur(w.duration) : '0:00';
-    d.hr = '--';
-    d.hrLabel = 'AVG HR';
-    d.stat4 = '--';
-    d.stat4Label = '';
-  }
-  d.timeLabel = 'TIME';
-  return d;
-}
-
-function formatDur(mins: number): string {
-  const h = Math.floor(mins / 60);
-  const m = Math.round(mins % 60);
-  if (h === 0) return `${m}min`;
-  return `${h}:${m.toString().padStart(2, '0')}`;
-}
-
-function formatDurLong(mins: number): string {
-  const h = Math.floor(mins / 60);
-  const m = Math.round(mins % 60);
-  if (h === 0) return `${m} min`;
-  if (m === 0) return `${h}h`;
-  return `${h}h ${m}m`;
-}
+// Calendar components
+import { CalendarHeader } from '@/components/calendar/CalendarHeader';
+import { CalendarMonthView } from '@/components/calendar/CalendarMonthView';
+import { MobileWeekStrip } from '@/components/calendar/MobileWeekStrip';
+import { CalendarDayWorkouts } from '@/components/calendar/CalendarDayWorkouts';
+import { WorkoutDetailPanel } from '@/components/calendar/WorkoutDetailPanel';
+import { CalendarSummary } from '@/components/calendar/CalendarSummary';
 
 export default function CalendarPage() {
   const user = useAuthStore((s) => s.user);
   const searchParams = useSearchParams();
   const [workouts, setWorkouts] = useState<Workout[]>([]);
   const [loading, setLoading] = useState(true);
+
+  // Desktop: month navigation
+  const [currentMonth, setCurrentMonth] = useState(() => new Date());
+  // Mobile: week navigation
   const [weekStart, setWeekStart] = useState(() => startOfWeek(new Date(), { weekStartsOn: 1 }));
-  const [activeTypes, setActiveTypes] = useState<Set<string>>(new Set(['swim', 'bike', 'run', 'strength', 'other']));
-  const [sendingReport, setSendingReport] = useState(false);
+  // Selected day (both mobile + desktop)
+  const [selectedDate, setSelectedDate] = useState<Date>(new Date());
+  // Selected workout for detail panel (desktop)
+  const [selectedWorkoutId, setSelectedWorkoutId] = useState<string | null>(null);
+
+  // Filters
+  const [activeTypes, setActiveTypes] = useState<Set<string>>(
+    new Set(['swim', 'bike', 'run', 'strength', 'other']),
+  );
+
+  // Coach features
   const [athletes, setAthletes] = useState<{ uid: string; displayName: string }[]>([]);
   const [selectedAthlete, setSelectedAthlete] = useState<string>('all');
   const isCoach = user?.role === 'coach';
 
-  // Fresh from onboarding Strava connect — skip cooldown, run progressive sync
+  // Report
+  const [sendingReport, setSendingReport] = useState(false);
+
+  // ── Strava sync ──────────────────────────────────────────────────────
   const fromStrava = searchParams.get('strava') === 'connected';
 
-  // Refresh workouts from Firestore (called after each sync phase)
   const refreshWorkouts = useCallback(async () => {
     if (!user) return;
     const data = await getUserWorkouts(user.username, user.role);
@@ -129,54 +65,67 @@ export default function CalendarPage() {
     setLoading(false);
   }, [user]);
 
-  // Progressive Strava sync — runs on the calendar when arriving from onboarding
   const { syncing, syncPhaseLabel } = useStravaAutoSync(
     fromStrava ? user : null,
     refreshWorkouts,
-    fromStrava, // skipCooldown
+    fromStrava,
   );
 
+  // ── Data loading ─────────────────────────────────────────────────────
   useEffect(() => {
     if (!user) return;
-    getUserWorkouts(user.username, user.role).then(data => {
+    getUserWorkouts(user.username, user.role).then((data) => {
       setWorkouts(data);
       setLoading(false);
     });
     if (isCoach) {
-      getCoachStudents(user.username).then(data => {
-        setAthletes(data.map((a: any) => ({ uid: a.uid, displayName: a.displayName || a.email || 'Unknown' })));
+      getCoachStudents(user.username).then((data) => {
+        setAthletes(
+          data.map((a: any) => ({
+            uid: a.uid,
+            displayName: a.displayName || a.email || 'Unknown',
+          })),
+        );
       });
     }
   }, [user, isCoach]);
 
-  const weekDays = useMemo(() =>
-    eachDayOfInterval({ start: weekStart, end: addDays(weekStart, 6) }),
-    [weekStart]
-  );
+  // ── Pre-computed workout lookup ──────────────────────────────────────
+  const workoutsByDate = useMemo(() => {
+    const map = new Map<string, Workout[]>();
+    workouts.forEach((w) => {
+      // Apply type filter
+      if (!activeTypes.has(w.type)) return;
+      // Apply athlete filter
+      if (isCoach && selectedAthlete !== 'all' && w.assignedTo !== selectedAthlete) return;
 
-  const getWorkoutsForDate = (date: Date) =>
-    workouts.filter(w => {
-      if (!activeTypes.has(w.type)) return false;
-      if (!isSameDay(w.date.toDate(), date)) return false;
-      if (isCoach && selectedAthlete !== 'all' && w.assignedTo !== selectedAthlete) return false;
-      return true;
+      const key = format(w.date.toDate(), 'yyyy-MM-dd');
+      if (!map.has(key)) map.set(key, []);
+      map.get(key)!.push(w);
     });
+    return map;
+  }, [workouts, activeTypes, isCoach, selectedAthlete]);
 
-  const weekSummary = useMemo(() => {
+  // ── Summary computation ──────────────────────────────────────────────
+  const summary = useMemo(() => {
+    // For desktop: compute for entire visible month
+    // For mobile: compute for current week
+    // We'll compute for the current week for the summary bar (consistent with previous behavior)
     const weekEnd = addDays(weekStart, 6);
-    const weekWorkouts = workouts.filter(w => {
+    const weekWorkouts = workouts.filter((w) => {
       const d = w.date.toDate();
       if (!(d >= weekStart && d <= weekEnd && activeTypes.has(w.type))) return false;
       if (isCoach && selectedAthlete !== 'all' && w.assignedTo !== selectedAthlete) return false;
       return true;
     });
-    const completed = weekWorkouts.filter(w => w.completed).length;
+
+    const completed = weekWorkouts.filter((w) => w.completed).length;
     const total = weekWorkouts.length;
     let totalDuration = 0;
     let totalDistance = 0;
     const byType: Record<string, { count: number; duration: number; distance: number }> = {};
 
-    weekWorkouts.forEach(w => {
+    weekWorkouts.forEach((w) => {
       const dur = w.duration || 0;
       totalDuration += dur;
       let dist = 0;
@@ -194,6 +143,7 @@ export default function CalendarPage() {
     return { completed, total, totalDuration, totalDistance, byType };
   }, [workouts, weekStart, activeTypes, selectedAthlete, isCoach]);
 
+  // ── Handlers ─────────────────────────────────────────────────────────
   const handleToggleComplete = async (e: React.MouseEvent, workout: Workout) => {
     e.preventDefault();
     e.stopPropagation();
@@ -205,6 +155,20 @@ export default function CalendarPage() {
     } catch (err: any) {
       toast.error(err.message || 'Failed to update');
     }
+  };
+
+  const handleToggleType = (type: string) => {
+    const next = new Set(activeTypes);
+    if (activeTypes.has(type) && activeTypes.size > 1) next.delete(type);
+    else next.add(type);
+    setActiveTypes(next);
+  };
+
+  const handleToday = () => {
+    const now = new Date();
+    setCurrentMonth(now);
+    setWeekStart(startOfWeek(now, { weekStartsOn: 1 }));
+    setSelectedDate(now);
   };
 
   const handleSendReport = async () => {
@@ -227,34 +191,63 @@ export default function CalendarPage() {
   };
 
   const generateICS = () => {
-    const weekEnd = addDays(weekStart, 6);
-    const weekWorkouts = workouts.filter(w => {
+    // Export current month's workouts
+    const monthStart = startOfMonth(currentMonth);
+    const monthEnd = endOfMonth(currentMonth);
+    const monthWorkouts = workouts.filter((w) => {
       const d = w.date.toDate();
-      return d >= weekStart && d <= weekEnd;
+      return d >= monthStart && d <= monthEnd;
     });
+
     const icsLines = [
-      'BEGIN:VCALENDAR', 'VERSION:2.0', 'PRODID:-//TheDailyAthlete//EN',
-      'CALSCALE:GREGORIAN', 'METHOD:PUBLISH',
+      'BEGIN:VCALENDAR',
+      'VERSION:2.0',
+      'PRODID:-//TheDailyAthlete//EN',
+      'CALSCALE:GREGORIAN',
+      'METHOD:PUBLISH',
     ];
-    weekWorkouts.forEach(w => {
+    monthWorkouts.forEach((w) => {
       const d = w.date.toDate();
       const dateStr = format(d, "yyyyMMdd'T'HHmmss");
-      const end = new Date(d); end.setMinutes(end.getMinutes() + (w.duration || 60));
-      icsLines.push('BEGIN:VEVENT', `UID:${w.id}@tda`, `DTSTART:${dateStr}`,
-        `DTEND:${format(end, "yyyyMMdd'T'HHmmss")}`, `SUMMARY:${w.name} (${w.type})`,
+      const end = new Date(d);
+      end.setMinutes(end.getMinutes() + (w.duration || 60));
+      icsLines.push(
+        'BEGIN:VEVENT',
+        `UID:${w.id}@tda`,
+        `DTSTART:${dateStr}`,
+        `DTEND:${format(end, "yyyyMMdd'T'HHmmss")}`,
+        `SUMMARY:${w.name} (${w.type})`,
         `DESCRIPTION:${(w.description || '').replace(/\n/g, '\\n')}`,
-        `STATUS:${w.completed ? 'COMPLETED' : 'CONFIRMED'}`, 'END:VEVENT');
+        `STATUS:${w.completed ? 'COMPLETED' : 'CONFIRMED'}`,
+        'END:VEVENT',
+      );
     });
     icsLines.push('END:VCALENDAR');
+
     const blob = new Blob([icsLines.join('\r\n')], { type: 'text/calendar' });
     const url = URL.createObjectURL(blob);
-    const a = document.createElement('a'); a.href = url;
-    a.download = `week-${format(weekStart, 'yyyy-MM-dd')}.ics`;
-    document.body.appendChild(a); a.click(); document.body.removeChild(a);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `calendar-${format(currentMonth, 'yyyy-MM')}.ics`;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
     URL.revokeObjectURL(url);
-    toast.success('Week exported!');
+    toast.success('Calendar exported!');
   };
 
+  // Find selected workout for detail panel
+  const selectedWorkout = selectedWorkoutId
+    ? workouts.find((w) => w.id === selectedWorkoutId) || null
+    : null;
+
+  // Workouts for selected date (mobile)
+  const selectedDateWorkouts = useMemo(() => {
+    const key = format(selectedDate, 'yyyy-MM-dd');
+    return workoutsByDate.get(key) || [];
+  }, [selectedDate, workoutsByDate]);
+
+  // ── Loading state ────────────────────────────────────────────────────
   if (loading) {
     return (
       <div className="flex items-center justify-center h-96">
@@ -263,248 +256,115 @@ export default function CalendarPage() {
     );
   }
 
-  const completionPct = weekSummary.total > 0 ? Math.round((weekSummary.completed / weekSummary.total) * 100) : 0;
-
   return (
     <div className="space-y-3">
-      {/* Header */}
-      <div className="flex items-center justify-between">
-        <div className="flex items-center gap-3">
-          <button onClick={() => setWeekStart(subWeeks(weekStart, 1))}
-            className="p-2.5 rounded-xl border hover:bg-muted transition-colors">
-            <ChevronLeft className="h-5 w-5" />
-          </button>
-          <div className="text-center min-w-[220px]">
-            <h1 className="text-xl font-bold tracking-tight">
-              {format(weekStart, 'MMM d')} — {format(addDays(weekStart, 6), 'MMM d, yyyy')}
-            </h1>
-            <p className="text-xs text-muted-foreground mt-0.5">Your weekly training plan</p>
-          </div>
-          <button onClick={() => setWeekStart(addWeeks(weekStart, 1))}
-            className="p-2.5 rounded-xl border hover:bg-muted transition-colors">
-            <ChevronRight className="h-5 w-5" />
-          </button>
-          <button
-            onClick={() => setWeekStart(startOfWeek(new Date(), { weekStartsOn: 1 }))}
-            className="px-4 py-2 rounded-lg text-xs font-bold bg-red-600 text-white hover:bg-red-700 transition-colors"
-          >Today</button>
-        </div>
-        <div className="flex items-center gap-2">
-          <div className="hidden md:flex items-center gap-1.5 mr-2">
-            {(['run', 'bike', 'swim', 'strength', 'other'] as const).map(type => {
-              const active = activeTypes.has(type);
-              const cfg = TYPE_CONFIG[type];
-              return (
-                <button key={type} onClick={() => {
-                  const next = new Set(activeTypes);
-                  if (active && activeTypes.size > 1) next.delete(type);
-                  else next.add(type);
-                  setActiveTypes(next);
-                }}
-                  className={cn(
-                    'px-3 py-1.5 rounded-full text-xs font-semibold border transition-all',
-                    active ? `${cfg.bg} ${cfg.color} border-current/20` : 'border-border text-muted-foreground/40'
-                  )}
-                >{cfg.emoji} {type}</button>
-              );
-            })}
-          </div>
-          {/* Athlete Picker (coach only) */}
-          {isCoach && athletes.length > 0 && (
-            <select
-              value={selectedAthlete}
-              onChange={(e) => setSelectedAthlete(e.target.value)}
-              className="px-3 py-1.5 rounded-lg text-xs font-semibold border bg-background cursor-pointer focus:outline-none focus:ring-2 focus:ring-red-500/30"
-            >
-              <option value="all">All Athletes</option>
-              {athletes.map(a => (
-                <option key={a.uid} value={a.uid}>{a.displayName}</option>
-              ))}
-            </select>
-          )}
-          <button onClick={generateICS}
-            className="p-2.5 rounded-xl border hover:bg-muted transition-colors" title="Export week">
-            <Download className="h-4 w-4" />
-          </button>
-          <button onClick={handleSendReport} disabled={sendingReport}
-            className="p-2.5 rounded-xl border hover:bg-muted transition-colors" title="Email report">
-            <Send className="h-4 w-4" />
-          </button>
-        </div>
-      </div>
+      {/* ═══ MOBILE LAYOUT (below md:) ═══ */}
+      <div className="md:hidden space-y-3">
+        <CalendarHeader
+          currentMonth={currentMonth}
+          onMonthChange={setCurrentMonth}
+          onToday={handleToday}
+          activeTypes={activeTypes}
+          onToggleType={handleToggleType}
+          isCoach={isCoach}
+          athletes={athletes}
+          selectedAthlete={selectedAthlete}
+          onSelectAthlete={setSelectedAthlete}
+          onExport={generateICS}
+          onSendReport={handleSendReport}
+          sendingReport={sendingReport}
+        />
 
-      {/* Weekly Summary Bar */}
-      <div className="flex items-center gap-6 px-5 py-3 rounded-xl border bg-muted/20">
-        <div className="flex items-center gap-2">
-          <div className="relative w-10 h-10">
-            <svg className="w-10 h-10 -rotate-90" viewBox="0 0 40 40">
-              <circle cx="20" cy="20" r="16" fill="none" stroke="currentColor" strokeWidth="3" className="text-muted/40" />
-              <circle cx="20" cy="20" r="16" fill="none" stroke="currentColor" strokeWidth="3"
-                className="text-green-500" strokeDasharray={`${completionPct * 1.005} 100.5`} strokeLinecap="round" />
-            </svg>
-            <span className="absolute inset-0 flex items-center justify-center text-[10px] font-black">{completionPct}%</span>
+        <MobileWeekStrip
+          weekStart={weekStart}
+          selectedDate={selectedDate}
+          onSelectDate={setSelectedDate}
+          onWeekChange={setWeekStart}
+          workoutsByDate={workoutsByDate}
+        />
+
+        <CalendarSummary {...summary} />
+
+        {/* Strava sync indicator */}
+        {syncing && (
+          <div className="flex items-center gap-3 px-4 py-2.5 rounded-xl border border-orange-500/20 bg-orange-500/5">
+            <Loader2 className="h-4 w-4 animate-spin text-orange-500 shrink-0" />
+            <p className="text-sm text-orange-600 dark:text-orange-400">
+              Syncing Strava workouts{syncPhaseLabel ? ` — ${syncPhaseLabel}` : ''}...
+            </p>
           </div>
-          <div>
-            <div className="text-xs font-bold">{weekSummary.completed}/{weekSummary.total}</div>
-            <div className="text-[10px] text-muted-foreground">completed</div>
-          </div>
-        </div>
-        <div className="h-8 w-px bg-border" />
-        <div>
-          <div className="text-xs font-bold flex items-center gap-1"><Timer className="h-3 w-3 opacity-50" />{formatDurLong(weekSummary.totalDuration)}</div>
-          <div className="text-[10px] text-muted-foreground">total time</div>
-        </div>
-        {weekSummary.totalDistance > 0 && (
-          <>
-            <div className="h-8 w-px bg-border" />
-            <div>
-              <div className="text-xs font-bold flex items-center gap-1"><Route className="h-3 w-3 opacity-50" />{weekSummary.totalDistance.toFixed(1)} km</div>
-              <div className="text-[10px] text-muted-foreground">distance</div>
-            </div>
-          </>
         )}
-        <div className="h-8 w-px bg-border" />
-        <div className="flex items-center gap-3">
-          {Object.entries(weekSummary.byType)
-            .sort((a, b) => b[1].count - a[1].count)
-            .map(([type, data]) => {
-              const cfg = TYPE_CONFIG[type] || TYPE_CONFIG.other;
-              return (
-                <div key={type} className="flex items-center gap-1">
-                  <span className="text-sm">{cfg.emoji}</span>
-                  <span className="text-xs font-bold">{data.count}</span>
-                  <span className="text-[10px] text-muted-foreground capitalize">{type}</span>
-                </div>
-              );
-            })}
-        </div>
+
+        <CalendarDayWorkouts
+          date={selectedDate}
+          workouts={selectedDateWorkouts}
+          onToggleComplete={handleToggleComplete}
+        />
       </div>
 
-      {/* Strava Sync Indicator */}
-      {syncing && (
-        <div className="flex items-center gap-3 px-4 py-2.5 rounded-xl border border-orange-500/20 bg-orange-500/5">
-          <Loader2 className="h-4 w-4 animate-spin text-orange-500 shrink-0" />
-          <p className="text-sm text-orange-600 dark:text-orange-400">
-            Syncing Strava workouts{syncPhaseLabel ? ` — ${syncPhaseLabel}` : ''}...
-          </p>
-        </div>
-      )}
+      {/* ═══ DESKTOP LAYOUT (md: and above) ═══ */}
+      <div className="hidden md:block">
+        <div className="space-y-3">
+          <CalendarHeader
+            currentMonth={currentMonth}
+            onMonthChange={setCurrentMonth}
+            onToday={handleToday}
+            activeTypes={activeTypes}
+            onToggleType={handleToggleType}
+            isCoach={isCoach}
+            athletes={athletes}
+            selectedAthlete={selectedAthlete}
+            onSelectAthlete={setSelectedAthlete}
+            onExport={generateICS}
+            onSendReport={handleSendReport}
+            sendingReport={sendingReport}
+          />
 
-      {/* Full-width Weekly Grid */}
-      <div className="flex gap-0 border rounded-2xl overflow-hidden" style={{ height: 'calc(100vh - 210px)' }}>
-        {weekDays.map((date) => {
-          const dayWorkouts = getWorkoutsForDate(date);
-          const today = isToday(date);
-          const past = isPast(date) && !today;
+          <CalendarSummary {...summary} />
 
-          let dayDuration = 0;
-          dayWorkouts.forEach(w => { dayDuration += w.duration || 0; });
-
-          return (
-            <div key={date.toISOString()}
-              className={cn(
-                'flex-1 min-w-0 flex flex-col border-r last:border-r-0',
-                today && 'bg-red-500/[0.03]',
-              )}
-            >
-              {/* Day Header */}
-              <div className={cn(
-                'px-2 py-4 border-b text-center shrink-0',
-                today ? 'bg-red-600 text-white' : 'bg-muted/30',
-              )}>
-                <div className={cn('text-[11px] font-semibold uppercase tracking-widest', today ? 'text-white/70' : 'opacity-50')}>
-                  {format(date, 'EEE')}
-                </div>
-                <div className={cn('text-3xl font-black mt-0.5', !today && 'text-foreground')}>
-                  {format(date, 'd')}
-                </div>
-                {dayWorkouts.length > 0 && (
-                  <div className={cn('mt-1 space-y-0.5', today ? 'text-white/60' : 'text-muted-foreground')}>
-                    <div className="text-[10px] font-semibold">
-                      {dayWorkouts.filter(w => w.completed).length}/{dayWorkouts.length} done
-                    </div>
-                    {dayDuration > 0 && (
-                      <div className="text-[10px]">{formatDurLong(dayDuration)}</div>
-                    )}
-                  </div>
-                )}
-              </div>
-
-              {/* Workout Cards */}
-              <div className="flex-1 p-2 space-y-2 overflow-y-auto">
-                {dayWorkouts.length === 0 && (
-                  <div className="flex flex-col items-center justify-center h-full opacity-15 gap-1">
-                    <div className="text-2xl">🌿</div>
-                    <span className="text-[11px] text-muted-foreground font-medium">Rest</span>
-                  </div>
-                )}
-
-                {dayWorkouts.map(workout => {
-                  const cfg = TYPE_CONFIG[workout.type] || TYPE_CONFIG.other;
-                  const stats = getTypeData(workout);
-                  const isMissed = past && !workout.completed;
-
-                  return (
-                    <Link key={workout.id} href={`/workouts/${workout.id}`}
-                      className={cn(
-                        'block rounded-lg border-l-[3px] transition-all hover:bg-muted/50',
-                        'border bg-card',
-                        cfg.border,
-                        isMissed && 'opacity-60',
-                      )}
-                    >
-                      {/* Top: icon + name + toggle */}
-                      <div className="flex items-start gap-2 px-3 pt-2.5 pb-1.5">
-                        <span className="text-lg mt-0.5 shrink-0">{cfg.emoji}</span>
-                        <div className="flex-1 min-w-0">
-                          <h3 className="text-[13px] font-bold leading-tight line-clamp-1">{workout.name}</h3>
-                          <p className={cn('text-[10px] font-semibold uppercase tracking-wider mt-0.5', cfg.color)}>{workout.type === 'strength' ? 'Strength Training' : workout.type === 'bike' ? 'Cycling' : workout.type === 'swim' ? 'Swimming' : workout.type === 'run' ? 'Running' : workout.type}</p>
-                        </div>
-                        <button
-                          onClick={(e) => handleToggleComplete(e, workout)}
-                          className="shrink-0 mt-0.5 opacity-40 hover:opacity-100 transition-opacity"
-                        >
-                          {workout.completed
-                            ? <CheckCircle2 className="h-4 w-4 text-green-500" />
-                            : <Circle className="h-4 w-4 text-muted-foreground" />}
-                        </button>
-                      </div>
-
-                      {/* Stats grid - Garmin style */}
-                      <div className="grid grid-cols-2 border-t mx-1 mb-1">
-                        <div className="px-2.5 py-1.5 border-r border-b">
-                          <div className="text-xs font-bold truncate">{stats.primary}</div>
-                          <div className="text-[9px] text-muted-foreground font-semibold tracking-wider">{stats.primaryLabel}</div>
-                        </div>
-                        <div className="px-2.5 py-1.5 border-b">
-                          <div className="text-xs font-bold">{stats.time}</div>
-                          <div className="text-[9px] text-muted-foreground font-semibold tracking-wider">{stats.timeLabel}</div>
-                        </div>
-                        <div className="px-2.5 py-1.5 border-r">
-                          <div className="text-xs font-bold">{stats.hr}{stats.hr !== '--' ? ' bpm' : ''}</div>
-                          <div className="text-[9px] text-muted-foreground font-semibold tracking-wider">{stats.hrLabel}</div>
-                        </div>
-                        <div className="px-2.5 py-1.5">
-                          <div className="text-xs font-bold">{stats.stat4}</div>
-                          <div className="text-[9px] text-muted-foreground font-semibold tracking-wider">{stats.stat4Label}</div>
-                        </div>
-                      </div>
-
-                      {/* Status badge */}
-                      {(isMissed || workout.completed) && (
-                        <div className="px-3 pb-2">
-                          {isMissed && <span className="text-[9px] font-bold text-red-500">MISSED</span>}
-                          {workout.completed && workout.completedLate && <span className="text-[9px] font-bold text-amber-500">LATE</span>}
-                          {workout.completed && !workout.completedLate && <span className="text-[9px] font-bold text-green-500">✓ DONE</span>}
-                        </div>
-                      )}
-                    </Link>
-                  );
-                })}
-              </div>
+          {/* Strava sync indicator */}
+          {syncing && (
+            <div className="flex items-center gap-3 px-4 py-2.5 rounded-xl border border-orange-500/20 bg-orange-500/5">
+              <Loader2 className="h-4 w-4 animate-spin text-orange-500 shrink-0" />
+              <p className="text-sm text-orange-600 dark:text-orange-400">
+                Syncing Strava workouts{syncPhaseLabel ? ` — ${syncPhaseLabel}` : ''}...
+              </p>
             </div>
-          );
-        })}
+          )}
+        </div>
+
+        {/* Month grid + detail panel side by side */}
+        <div className="flex gap-0 mt-3">
+          <div className="flex-1 min-w-0">
+            <CalendarMonthView
+              currentMonth={currentMonth}
+              workoutsByDate={workoutsByDate}
+              selectedDate={selectedDate}
+              onSelectDate={(date) => {
+                setSelectedDate(date);
+                // If there's only one workout on that day, auto-select it
+                const key = format(date, 'yyyy-MM-dd');
+                const dayWorkouts = workoutsByDate.get(key) || [];
+                if (dayWorkouts.length === 1) {
+                  setSelectedWorkoutId(dayWorkouts[0].id);
+                } else {
+                  setSelectedWorkoutId(null);
+                }
+              }}
+              onSelectWorkout={(id) => setSelectedWorkoutId(id)}
+              activeTypes={activeTypes}
+            />
+          </div>
+
+          {/* Detail panel */}
+          {selectedWorkout && (
+            <WorkoutDetailPanel
+              workout={selectedWorkout}
+              onClose={() => setSelectedWorkoutId(null)}
+              onToggleComplete={handleToggleComplete}
+            />
+          )}
+        </div>
       </div>
     </div>
   );

--- a/src/components/calendar/CalendarDayWorkouts.tsx
+++ b/src/components/calendar/CalendarDayWorkouts.tsx
@@ -1,0 +1,87 @@
+'use client';
+
+import { Workout } from '@/types';
+import { CalendarWorkoutCard } from './CalendarWorkoutCard';
+import { format, isPast, isToday } from 'date-fns';
+import { Plus } from 'lucide-react';
+import Link from 'next/link';
+
+interface CalendarDayWorkoutsProps {
+  date: Date;
+  workouts: Workout[];
+  onToggleComplete?: (e: React.MouseEvent, workout: Workout) => void;
+}
+
+export function CalendarDayWorkouts({
+  date,
+  workouts,
+  onToggleComplete,
+}: CalendarDayWorkoutsProps) {
+  const today = isToday(date);
+  const past = isPast(date) && !today;
+
+  // Split workouts into planned (future/upcoming) and past/completed
+  const planned = workouts.filter((w) => {
+    const wDate = w.date.toDate();
+    return !isPast(wDate) || isToday(wDate);
+  });
+  const pastWorkouts = workouts.filter((w) => {
+    const wDate = w.date.toDate();
+    return isPast(wDate) && !isToday(wDate);
+  });
+
+  // For a single selected day, show all workouts together
+  // The planned/past split is more useful when showing multiple days
+  const allWorkouts = workouts;
+
+  const dateStr = format(date, 'yyyy-MM-dd');
+
+  return (
+    <div className="space-y-3">
+      {/* Day header */}
+      <div className="flex items-center justify-between px-1">
+        <div>
+          <h3 className="text-sm font-bold uppercase tracking-wider text-muted-foreground">
+            {format(date, 'EEE')}
+          </h3>
+          <p className="text-2xl font-black">{format(date, 'd')}</p>
+        </div>
+        {allWorkouts.length > 0 && (
+          <span className="text-xs text-muted-foreground">
+            {allWorkouts.length} workout{allWorkouts.length !== 1 ? 's' : ''}
+          </span>
+        )}
+      </div>
+
+      {/* Workout cards */}
+      {allWorkouts.length > 0 ? (
+        <div className="space-y-2">
+          {allWorkouts.map((workout) => (
+            <CalendarWorkoutCard
+              key={workout.id}
+              workout={workout}
+              compact
+              onToggleComplete={onToggleComplete}
+            />
+          ))}
+        </div>
+      ) : (
+        <div className="flex flex-col items-center justify-center py-12 opacity-40 gap-2">
+          <div className="text-3xl">🌿</div>
+          <span className="text-sm text-muted-foreground font-medium">
+            Rest day
+          </span>
+        </div>
+      )}
+
+      {/* + Add Plan button */}
+      <Link
+        href={`/workouts/new?date=${dateStr}`}
+        className="flex items-center justify-center gap-2 w-full py-2.5 rounded-xl border border-dashed border-muted-foreground/30 text-sm font-medium text-muted-foreground hover:border-primary/50 hover:text-primary transition-colors"
+      >
+        <Plus className="h-4 w-4" />
+        Add Plan
+      </Link>
+    </div>
+  );
+}

--- a/src/components/calendar/CalendarHeader.tsx
+++ b/src/components/calendar/CalendarHeader.tsx
@@ -1,0 +1,215 @@
+'use client';
+
+import { TYPE_CONFIG } from './types';
+import {
+  ChevronLeft,
+  ChevronRight,
+  Download,
+  Send,
+  Plus,
+  MoreHorizontal,
+} from 'lucide-react';
+import { format, addMonths, subMonths } from 'date-fns';
+import Link from 'next/link';
+import { cn } from '@/lib/utils';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+
+interface CalendarHeaderProps {
+  currentMonth: Date;
+  onMonthChange: (date: Date) => void;
+  onToday: () => void;
+  activeTypes: Set<string>;
+  onToggleType: (type: string) => void;
+  // Coach features
+  isCoach?: boolean;
+  athletes?: { uid: string; displayName: string }[];
+  selectedAthlete?: string;
+  onSelectAthlete?: (uid: string) => void;
+  // Actions
+  onExport?: () => void;
+  onSendReport?: () => void;
+  sendingReport?: boolean;
+}
+
+export function CalendarHeader({
+  currentMonth,
+  onMonthChange,
+  onToday,
+  activeTypes,
+  onToggleType,
+  isCoach,
+  athletes = [],
+  selectedAthlete = 'all',
+  onSelectAthlete,
+  onExport,
+  onSendReport,
+  sendingReport,
+}: CalendarHeaderProps) {
+  return (
+    <div className="space-y-2">
+      {/* Main header row */}
+      <div className="flex items-center justify-between">
+        {/* Left: Today + navigation */}
+        <div className="flex items-center gap-2">
+          <button
+            onClick={onToday}
+            className="px-3 py-1.5 rounded-lg text-xs font-bold bg-red-600 text-white hover:bg-red-700 transition-colors"
+          >
+            Today
+          </button>
+          <button
+            onClick={() => onMonthChange(subMonths(currentMonth, 1))}
+            className="p-2 rounded-xl border hover:bg-muted transition-colors"
+          >
+            <ChevronLeft className="h-4 w-4" />
+          </button>
+          <button
+            onClick={() => onMonthChange(addMonths(currentMonth, 1))}
+            className="p-2 rounded-xl border hover:bg-muted transition-colors"
+          >
+            <ChevronRight className="h-4 w-4" />
+          </button>
+        </div>
+
+        {/* Center: Month/Year */}
+        <h1 className="text-lg md:text-xl font-bold tracking-tight uppercase">
+          {format(currentMonth, 'MMMM yyyy')}
+        </h1>
+
+        {/* Right: Actions */}
+        <div className="flex items-center gap-2">
+          {/* Type filters — desktop only */}
+          <div className="hidden lg:flex items-center gap-1.5 mr-2">
+            {(['run', 'bike', 'swim', 'strength', 'other'] as const).map((type) => {
+              const active = activeTypes.has(type);
+              const cfg = TYPE_CONFIG[type];
+              return (
+                <button
+                  key={type}
+                  onClick={() => onToggleType(type)}
+                  className={cn(
+                    'px-3 py-1.5 rounded-full text-xs font-semibold border transition-all',
+                    active
+                      ? `${cfg.bg} ${cfg.color} border-current/20`
+                      : 'border-border text-muted-foreground/40',
+                  )}
+                >
+                  {cfg.emoji} {type}
+                </button>
+              );
+            })}
+          </div>
+
+          {/* Coach athlete picker */}
+          {isCoach && athletes.length > 0 && (
+            <select
+              value={selectedAthlete}
+              onChange={(e) => onSelectAthlete?.(e.target.value)}
+              className="hidden md:block px-3 py-1.5 rounded-lg text-xs font-semibold border bg-background cursor-pointer focus:outline-none focus:ring-2 focus:ring-red-500/30"
+            >
+              <option value="all">All Athletes</option>
+              {athletes.map((a) => (
+                <option key={a.uid} value={a.uid}>
+                  {a.displayName}
+                </option>
+              ))}
+            </select>
+          )}
+
+          {/* Add Workout button */}
+          <Link
+            href="/workouts/new"
+            className="hidden md:flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-semibold bg-primary text-primary-foreground hover:bg-primary/90 transition-colors"
+          >
+            <Plus className="h-3.5 w-3.5" />
+            Add Workout
+          </Link>
+
+          {/* Desktop action buttons */}
+          <button
+            onClick={onExport}
+            className="hidden md:flex p-2 rounded-xl border hover:bg-muted transition-colors"
+            title="Export calendar"
+          >
+            <Download className="h-4 w-4" />
+          </button>
+          <button
+            onClick={onSendReport}
+            disabled={sendingReport}
+            className="hidden md:flex p-2 rounded-xl border hover:bg-muted transition-colors"
+            title="Email report"
+          >
+            <Send className="h-4 w-4" />
+          </button>
+
+          {/* Mobile overflow menu */}
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <button className="md:hidden p-2 rounded-xl border hover:bg-muted transition-colors">
+                <MoreHorizontal className="h-4 w-4" />
+              </button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              <DropdownMenuItem asChild>
+                <Link href="/workouts/new" className="flex items-center gap-2">
+                  <Plus className="h-4 w-4" />
+                  Add Workout
+                </Link>
+              </DropdownMenuItem>
+              <DropdownMenuItem onClick={onExport}>
+                <Download className="h-4 w-4 mr-2" />
+                Export Calendar
+              </DropdownMenuItem>
+              <DropdownMenuItem onClick={onSendReport} disabled={sendingReport}>
+                <Send className="h-4 w-4 mr-2" />
+                Email Report
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
+      </div>
+
+      {/* Mobile filter pills — horizontally scrollable */}
+      <div className="flex lg:hidden items-center gap-1.5 overflow-x-auto pb-1 -mx-1 px-1">
+        {(['run', 'bike', 'swim', 'strength', 'other'] as const).map((type) => {
+          const active = activeTypes.has(type);
+          const cfg = TYPE_CONFIG[type];
+          return (
+            <button
+              key={type}
+              onClick={() => onToggleType(type)}
+              className={cn(
+                'shrink-0 px-2.5 py-1 rounded-full text-[11px] font-semibold border transition-all',
+                active
+                  ? `${cfg.bg} ${cfg.color} border-current/20`
+                  : 'border-border text-muted-foreground/40',
+              )}
+            >
+              {cfg.emoji} {type}
+            </button>
+          );
+        })}
+        {/* Mobile athlete picker inline */}
+        {isCoach && athletes.length > 0 && (
+          <select
+            value={selectedAthlete}
+            onChange={(e) => onSelectAthlete?.(e.target.value)}
+            className="shrink-0 px-2.5 py-1 rounded-full text-[11px] font-semibold border bg-background cursor-pointer"
+          >
+            <option value="all">All Athletes</option>
+            {athletes.map((a) => (
+              <option key={a.uid} value={a.uid}>
+                {a.displayName}
+              </option>
+            ))}
+          </select>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/calendar/CalendarMonthView.tsx
+++ b/src/components/calendar/CalendarMonthView.tsx
@@ -1,0 +1,141 @@
+'use client';
+
+import { useMemo } from 'react';
+import { Workout } from '@/types';
+import { CalendarWorkoutCard } from './CalendarWorkoutCard';
+import {
+  startOfMonth,
+  endOfMonth,
+  startOfWeek,
+  endOfWeek,
+  eachDayOfInterval,
+  isSameMonth,
+  isSameDay,
+  isToday,
+  format,
+} from 'date-fns';
+import { cn } from '@/lib/utils';
+
+const DAY_HEADERS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+
+interface CalendarMonthViewProps {
+  currentMonth: Date;
+  workoutsByDate: Map<string, Workout[]>;
+  selectedDate: Date | null;
+  onSelectDate: (date: Date) => void;
+  onSelectWorkout: (workoutId: string) => void;
+  activeTypes: Set<string>;
+  /** Max pills to show per cell before "+N more" */
+  maxPillsPerCell?: number;
+}
+
+export function CalendarMonthView({
+  currentMonth,
+  workoutsByDate,
+  selectedDate,
+  onSelectDate,
+  onSelectWorkout,
+  activeTypes,
+  maxPillsPerCell = 3,
+}: CalendarMonthViewProps) {
+  // Build the 6-week grid (always show 6 rows for consistent height)
+  const calendarDays = useMemo(() => {
+    const monthStart = startOfMonth(currentMonth);
+    const monthEnd = endOfMonth(currentMonth);
+    const gridStart = startOfWeek(monthStart, { weekStartsOn: 0 }); // Sunday
+    const gridEnd = endOfWeek(monthEnd, { weekStartsOn: 0 });
+    return eachDayOfInterval({ start: gridStart, end: gridEnd });
+  }, [currentMonth]);
+
+  // Group days into weeks (rows of 7)
+  const weeks = useMemo(() => {
+    const result: Date[][] = [];
+    for (let i = 0; i < calendarDays.length; i += 7) {
+      result.push(calendarDays.slice(i, i + 7));
+    }
+    return result;
+  }, [calendarDays]);
+
+  return (
+    <div
+      className="border rounded-2xl overflow-hidden flex flex-col"
+      style={{ height: 'calc(100vh - 230px)' }}
+    >
+      {/* Day-of-week header */}
+      <div className="grid grid-cols-7 border-b bg-muted/30">
+        {DAY_HEADERS.map((day) => (
+          <div
+            key={day}
+            className="px-2 py-2 text-center text-[11px] font-semibold uppercase tracking-widest text-muted-foreground"
+          >
+            {day}
+          </div>
+        ))}
+      </div>
+
+      {/* Calendar grid */}
+      <div className="flex-1 grid grid-rows-[repeat(auto-fill,minmax(0,1fr))]">
+        {weeks.map((week, weekIdx) => (
+          <div key={weekIdx} className="grid grid-cols-7 border-b last:border-b-0">
+            {week.map((day) => {
+              const dateKey = format(day, 'yyyy-MM-dd');
+              const dayWorkouts = (workoutsByDate.get(dateKey) || []).filter((w) =>
+                activeTypes.has(w.type),
+              );
+              const inMonth = isSameMonth(day, currentMonth);
+              const today = isToday(day);
+              const selected = selectedDate ? isSameDay(day, selectedDate) : false;
+              const visibleWorkouts = dayWorkouts.slice(0, maxPillsPerCell);
+              const overflow = dayWorkouts.length - maxPillsPerCell;
+
+              return (
+                <div
+                  key={dateKey}
+                  onClick={() => onSelectDate(day)}
+                  className={cn(
+                    'border-r last:border-r-0 px-1.5 py-1.5 cursor-pointer transition-colors min-h-0 overflow-hidden flex flex-col',
+                    !inMonth && 'bg-muted/10',
+                    selected && 'bg-primary/5 ring-1 ring-inset ring-primary/30',
+                    today && !selected && 'bg-red-500/[0.03]',
+                    'hover:bg-muted/30',
+                  )}
+                >
+                  {/* Date number */}
+                  <div className="flex items-center justify-between mb-1">
+                    <span
+                      className={cn(
+                        'text-sm font-bold w-7 h-7 flex items-center justify-center rounded-full',
+                        !inMonth && 'text-muted-foreground/40',
+                        today && 'bg-red-600 text-white',
+                        !today && inMonth && 'text-foreground',
+                      )}
+                    >
+                      {format(day, 'd')}
+                    </span>
+                  </div>
+
+                  {/* Workout mini-pills */}
+                  <div className="flex-1 space-y-0.5 min-h-0 overflow-hidden">
+                    {visibleWorkouts.map((workout) => (
+                      <CalendarWorkoutCard
+                        key={workout.id}
+                        workout={workout}
+                        compact={false}
+                        onSelect={onSelectWorkout}
+                      />
+                    ))}
+                    {overflow > 0 && (
+                      <div className="text-[10px] text-muted-foreground font-medium pl-1">
+                        +{overflow} more
+                      </div>
+                    )}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/calendar/CalendarSummary.tsx
+++ b/src/components/calendar/CalendarSummary.tsx
@@ -1,0 +1,94 @@
+'use client';
+
+import { TYPE_CONFIG, formatDurLong } from './types';
+import { Timer, Route } from 'lucide-react';
+
+interface CalendarSummaryProps {
+  completed: number;
+  total: number;
+  totalDuration: number;
+  totalDistance: number;
+  byType: Record<string, { count: number; duration: number; distance: number }>;
+}
+
+export function CalendarSummary({
+  completed,
+  total,
+  totalDuration,
+  totalDistance,
+  byType,
+}: CalendarSummaryProps) {
+  const completionPct = total > 0 ? Math.round((completed / total) * 100) : 0;
+
+  return (
+    <div className="flex items-center gap-4 md:gap-6 px-4 md:px-5 py-2.5 md:py-3 rounded-xl border bg-muted/20 overflow-x-auto">
+      {/* Completion ring */}
+      <div className="flex items-center gap-2 shrink-0">
+        <div className="relative w-9 h-9 md:w-10 md:h-10">
+          <svg className="w-full h-full -rotate-90" viewBox="0 0 40 40">
+            <circle
+              cx="20" cy="20" r="16" fill="none" stroke="currentColor"
+              strokeWidth="3" className="text-muted/40"
+            />
+            <circle
+              cx="20" cy="20" r="16" fill="none" stroke="currentColor"
+              strokeWidth="3" className="text-green-500"
+              strokeDasharray={`${completionPct * 1.005} 100.5`}
+              strokeLinecap="round"
+            />
+          </svg>
+          <span className="absolute inset-0 flex items-center justify-center text-[10px] font-black">
+            {completionPct}%
+          </span>
+        </div>
+        <div>
+          <div className="text-xs font-bold">{completed}/{total}</div>
+          <div className="text-[10px] text-muted-foreground">completed</div>
+        </div>
+      </div>
+
+      <div className="h-8 w-px bg-border shrink-0" />
+
+      {/* Total time */}
+      <div className="shrink-0">
+        <div className="text-xs font-bold flex items-center gap-1">
+          <Timer className="h-3 w-3 opacity-50" />
+          {formatDurLong(totalDuration)}
+        </div>
+        <div className="text-[10px] text-muted-foreground">total time</div>
+      </div>
+
+      {/* Distance */}
+      {totalDistance > 0 && (
+        <>
+          <div className="h-8 w-px bg-border shrink-0" />
+          <div className="shrink-0">
+            <div className="text-xs font-bold flex items-center gap-1">
+              <Route className="h-3 w-3 opacity-50" />
+              {totalDistance.toFixed(1)} km
+            </div>
+            <div className="text-[10px] text-muted-foreground">distance</div>
+          </div>
+        </>
+      )}
+
+      <div className="h-8 w-px bg-border shrink-0" />
+
+      {/* Type breakdown */}
+      <div className="flex items-center gap-3 shrink-0">
+        {Object.entries(byType)
+          .sort((a, b) => b[1].count - a[1].count)
+          .map(([type, data]) => {
+            const cfg = TYPE_CONFIG[type] || TYPE_CONFIG.other;
+            return (
+              <div key={type} className="flex items-center gap-1">
+                <span className="text-sm">{cfg.emoji}</span>
+                <span className="text-xs font-bold">{data.count}</span>
+                <span className="text-[10px] text-muted-foreground capitalize">{type}</span>
+              </div>
+            );
+          })}
+      </div>
+    </div>
+  );
+}

--- a/src/components/calendar/CalendarWorkoutCard.tsx
+++ b/src/components/calendar/CalendarWorkoutCard.tsx
@@ -1,0 +1,182 @@
+'use client';
+
+import { Workout } from '@/types';
+import { TYPE_CONFIG, TYPE_LABELS, getTypeData, formatDur } from './types';
+import { CheckCircle2, Circle, Activity } from 'lucide-react';
+import { format, isPast, isToday } from 'date-fns';
+import Link from 'next/link';
+import { cn } from '@/lib/utils';
+
+interface CalendarWorkoutCardProps {
+  workout: Workout;
+  /** true = mobile compact list card, false = month grid mini-pill */
+  compact?: boolean;
+  onToggleComplete?: (e: React.MouseEvent, workout: Workout) => void;
+  /** Called when the pill is clicked in month view */
+  onSelect?: (workoutId: string) => void;
+}
+
+/**
+ * Month grid mini-pill: small colored pill with emoji + name + key stat.
+ * Used inside CalendarMonthView cells.
+ */
+function MiniPill({ workout, onSelect }: { workout: Workout; onSelect?: (id: string) => void }) {
+  const cfg = TYPE_CONFIG[workout.type] || TYPE_CONFIG.other;
+  const stats = getTypeData(workout);
+  const workoutDate = workout.date.toDate();
+  const timeStr = format(workoutDate, 'h:mma').toLowerCase();
+
+  return (
+    <button
+      onClick={(e) => {
+        e.stopPropagation();
+        onSelect?.(workout.id);
+      }}
+      className={cn(
+        'w-full text-left rounded-md border-l-[3px] px-2 py-1 transition-all',
+        'hover:bg-muted/60 cursor-pointer',
+        'bg-card/80',
+        cfg.border,
+      )}
+    >
+      <div className="flex items-center gap-1.5 min-w-0">
+        <span className="text-xs shrink-0">{cfg.emoji}</span>
+        <span className="text-[11px] font-semibold truncate flex-1">{workout.name}</span>
+        {workout.completed && (
+          <CheckCircle2 className="h-3 w-3 text-green-500 shrink-0" />
+        )}
+        {workout.source === 'strava' && !workout.completed && (
+          <Activity className="h-3 w-3 text-orange-500 shrink-0" />
+        )}
+      </div>
+      <div className="flex items-center gap-1.5 text-[10px] text-muted-foreground mt-0.5">
+        <span>{timeStr}</span>
+        {stats.primary !== '--' && (
+          <>
+            <span className="opacity-40">·</span>
+            <span className="truncate">{stats.primary}</span>
+          </>
+        )}
+      </div>
+    </button>
+  );
+}
+
+/**
+ * Compact card: for mobile day workout list.
+ * Shows emoji + name + badges + stats in a tappable card.
+ */
+function CompactCard({
+  workout,
+  onToggleComplete,
+}: {
+  workout: Workout;
+  onToggleComplete?: (e: React.MouseEvent, workout: Workout) => void;
+}) {
+  const cfg = TYPE_CONFIG[workout.type] || TYPE_CONFIG.other;
+  const stats = getTypeData(workout);
+  const workoutDate = workout.date.toDate();
+  const timeStr = format(workoutDate, 'h:mm a');
+  const today = isToday(workoutDate);
+  const past = isPast(workoutDate) && !today;
+  const isMissed = past && !workout.completed;
+  const isPlanned = !workout.completed && !past;
+  const isStrava = workout.source === 'strava' || workout.completedBy === 'strava';
+
+  return (
+    <Link
+      href={`/workouts/${workout.id}`}
+      className={cn(
+        'block rounded-xl border transition-all hover:shadow-sm',
+        'bg-card',
+        isMissed && 'opacity-60',
+      )}
+    >
+      <div className="flex items-start gap-3 p-3.5">
+        {/* Emoji */}
+        <span className="text-xl mt-0.5 shrink-0">{cfg.emoji}</span>
+
+        {/* Content */}
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2">
+            <h3 className="text-sm font-bold leading-tight truncate">{workout.name}</h3>
+            {/* Status badge */}
+            {isPlanned && (
+              <span className="shrink-0 px-2 py-0.5 rounded-full text-[10px] font-semibold bg-blue-500/10 text-blue-600 dark:text-blue-400 border border-blue-500/20">
+                Planned
+              </span>
+            )}
+            {workout.completed && !workout.completedLate && (
+              <span className="shrink-0 px-2 py-0.5 rounded-full text-[10px] font-semibold bg-green-500/10 text-green-600 dark:text-green-400 border border-green-500/20">
+                Done
+              </span>
+            )}
+            {workout.completedLate && (
+              <span className="shrink-0 px-2 py-0.5 rounded-full text-[10px] font-semibold bg-amber-500/10 text-amber-600 dark:text-amber-400 border border-amber-500/20">
+                Late
+              </span>
+            )}
+            {isMissed && (
+              <span className="shrink-0 px-2 py-0.5 rounded-full text-[10px] font-semibold bg-red-500/10 text-red-600 dark:text-red-400 border border-red-500/20">
+                Missed
+              </span>
+            )}
+          </div>
+          <div className="flex items-center gap-1.5 text-xs text-muted-foreground mt-1">
+            <span>{timeStr}</span>
+            <span className="opacity-40">·</span>
+            <span>{stats.time}</span>
+            {stats.primary !== '--' && (
+              <>
+                <span className="opacity-40">·</span>
+                <span>{stats.primary}</span>
+              </>
+            )}
+            {workout.tags && workout.tags.length > 0 && (
+              <>
+                <span className="opacity-40">·</span>
+                <span className="capitalize">{workout.tags[0]}</span>
+              </>
+            )}
+          </div>
+        </div>
+
+        {/* Source badge + completion toggle */}
+        <div className="flex items-center gap-2 shrink-0">
+          {isStrava && (
+            <span className="flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-bold bg-orange-500/10 text-orange-600 border border-orange-500/20">
+              <Activity className="h-3 w-3" />S
+            </span>
+          )}
+          {onToggleComplete && (
+            <button
+              onClick={(e) => onToggleComplete(e, workout)}
+              className="opacity-40 hover:opacity-100 transition-opacity"
+            >
+              {workout.completed ? (
+                <CheckCircle2 className="h-5 w-5 text-green-500" />
+              ) : (
+                <Circle className="h-5 w-5 text-muted-foreground" />
+              )}
+            </button>
+          )}
+        </div>
+      </div>
+    </Link>
+  );
+}
+
+/**
+ * CalendarWorkoutCard — renders as mini-pill (month grid) or compact card (mobile list).
+ */
+export function CalendarWorkoutCard({
+  workout,
+  compact = false,
+  onToggleComplete,
+  onSelect,
+}: CalendarWorkoutCardProps) {
+  if (compact) {
+    return <CompactCard workout={workout} onToggleComplete={onToggleComplete} />;
+  }
+  return <MiniPill workout={workout} onSelect={onSelect} />;
+}

--- a/src/components/calendar/MobileWeekStrip.tsx
+++ b/src/components/calendar/MobileWeekStrip.tsx
@@ -1,0 +1,166 @@
+'use client';
+
+import { useRef, useCallback } from 'react';
+import { Workout } from '@/types';
+import { TYPE_CONFIG } from './types';
+import {
+  format,
+  eachDayOfInterval,
+  addDays,
+  addWeeks,
+  subWeeks,
+  isSameDay,
+  isToday,
+} from 'date-fns';
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+interface MobileWeekStripProps {
+  weekStart: Date;
+  selectedDate: Date;
+  onSelectDate: (date: Date) => void;
+  onWeekChange: (weekStart: Date) => void;
+  workoutsByDate: Map<string, Workout[]>;
+}
+
+export function MobileWeekStrip({
+  weekStart,
+  selectedDate,
+  onSelectDate,
+  onWeekChange,
+  workoutsByDate,
+}: MobileWeekStripProps) {
+  const weekEnd = addDays(weekStart, 6);
+  const weekDays = eachDayOfInterval({ start: weekStart, end: weekEnd });
+
+  // Swipe handling
+  const touchStartX = useRef<number | null>(null);
+
+  const handleTouchStart = useCallback((e: React.TouchEvent) => {
+    touchStartX.current = e.touches[0].clientX;
+  }, []);
+
+  const handleTouchEnd = useCallback(
+    (e: React.TouchEvent) => {
+      if (touchStartX.current === null) return;
+      const delta = e.changedTouches[0].clientX - touchStartX.current;
+      if (Math.abs(delta) > 60) {
+        if (delta > 0) {
+          onWeekChange(subWeeks(weekStart, 1));
+        } else {
+          onWeekChange(addWeeks(weekStart, 1));
+        }
+      }
+      touchStartX.current = null;
+    },
+    [weekStart, onWeekChange],
+  );
+
+  return (
+    <div className="space-y-3">
+      {/* Week date range + navigation */}
+      <div className="flex items-center justify-between px-1">
+        <button
+          onClick={() => onWeekChange(subWeeks(weekStart, 1))}
+          className="p-2 rounded-xl border hover:bg-muted transition-colors"
+        >
+          <ChevronLeft className="h-4 w-4" />
+        </button>
+        <h2 className="text-base font-bold">
+          {format(weekStart, 'MMM d')} - {format(weekEnd, 'd')}
+        </h2>
+        <button
+          onClick={() => onWeekChange(addWeeks(weekStart, 1))}
+          className="p-2 rounded-xl border hover:bg-muted transition-colors"
+        >
+          <ChevronRight className="h-4 w-4" />
+        </button>
+      </div>
+
+      {/* Day circles */}
+      <div
+        className="grid grid-cols-7 gap-1"
+        onTouchStart={handleTouchStart}
+        onTouchEnd={handleTouchEnd}
+      >
+        {weekDays.map((day) => {
+          const dateKey = format(day, 'yyyy-MM-dd');
+          const dayWorkouts = workoutsByDate.get(dateKey) || [];
+          const selected = isSameDay(day, selectedDate);
+          const today = isToday(day);
+
+          // Collect unique workout type colors for dots
+          const typeDots = Array.from(
+            new Set(dayWorkouts.map((w) => w.type)),
+          ).slice(0, 3);
+
+          return (
+            <button
+              key={dateKey}
+              onClick={() => onSelectDate(day)}
+              className={cn(
+                'flex flex-col items-center py-2 rounded-xl transition-all',
+                selected
+                  ? 'bg-primary text-primary-foreground shadow-sm'
+                  : today
+                    ? 'bg-red-500/10'
+                    : 'hover:bg-muted',
+              )}
+            >
+              {/* Day abbreviation */}
+              <span
+                className={cn(
+                  'text-[10px] font-semibold uppercase tracking-wider',
+                  selected ? 'text-primary-foreground/70' : 'text-muted-foreground',
+                )}
+              >
+                {format(day, 'EEE')}
+              </span>
+
+              {/* Date number */}
+              <span
+                className={cn(
+                  'text-lg font-black mt-0.5',
+                  selected && 'text-primary-foreground',
+                  !selected && today && 'text-red-600',
+                )}
+              >
+                {format(day, 'd')}
+              </span>
+
+              {/* Active label or workout dots */}
+              {selected ? (
+                <span className="text-[9px] font-bold uppercase tracking-wider text-primary-foreground/70 mt-0.5">
+                  Active
+                </span>
+              ) : (
+                <div className="flex items-center gap-0.5 mt-1 h-2">
+                  {typeDots.map((type) => {
+                    const cfg = TYPE_CONFIG[type] || TYPE_CONFIG.other;
+                    // Map text color classes to actual dot colors
+                    const dotColor =
+                      type === 'run'
+                        ? 'bg-red-500'
+                        : type === 'bike'
+                          ? 'bg-amber-500'
+                          : type === 'swim'
+                            ? 'bg-cyan-500'
+                            : type === 'strength'
+                              ? 'bg-purple-500'
+                              : 'bg-gray-400';
+                    return (
+                      <div
+                        key={type}
+                        className={cn('w-1.5 h-1.5 rounded-full', dotColor)}
+                      />
+                    );
+                  })}
+                </div>
+              )}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/components/calendar/WorkoutDetailPanel.tsx
+++ b/src/components/calendar/WorkoutDetailPanel.tsx
@@ -1,0 +1,248 @@
+'use client';
+
+import { Workout } from '@/types';
+import { TYPE_CONFIG, TYPE_LABELS, getTypeData, formatDurLong } from './types';
+import { MiniRoutePreview } from '@/components/workouts/MiniRoutePreview';
+import { WorkoutPhotos } from '@/components/workouts/WorkoutPhotos';
+import {
+  X,
+  CheckCircle2,
+  Circle,
+  Activity,
+  ExternalLink,
+  Clock,
+  MapPin,
+  Mountain,
+  Heart,
+  Zap,
+} from 'lucide-react';
+import { format, isPast, isToday } from 'date-fns';
+import Link from 'next/link';
+import { cn } from '@/lib/utils';
+
+interface WorkoutDetailPanelProps {
+  workout: Workout;
+  onClose: () => void;
+  onToggleComplete?: (e: React.MouseEvent, workout: Workout) => void;
+}
+
+export function WorkoutDetailPanel({
+  workout,
+  onClose,
+  onToggleComplete,
+}: WorkoutDetailPanelProps) {
+  const cfg = TYPE_CONFIG[workout.type] || TYPE_CONFIG.other;
+  const stats = getTypeData(workout);
+  const workoutDate = workout.date.toDate();
+  const today = isToday(workoutDate);
+  const past = isPast(workoutDate) && !today;
+  const isMissed = past && !workout.completed;
+  const isStrava = workout.source === 'strava' || workout.completedBy === 'strava';
+  const hasRoute = !!(workout.routeData?.polyline);
+
+  // Extract detailed stats for the grid
+  const duration = workout.duration ? formatDurLong(workout.duration) : '--';
+  const distance =
+    workout.run?.distance
+      ? `${workout.run.distance} ${workout.run.distanceUnit || 'km'}`
+      : workout.bike?.distance
+        ? `${workout.bike.distance} ${workout.bike.distanceUnit || 'km'}`
+        : workout.swim?.distance
+          ? `${workout.swim.distance} ${workout.swim.distanceUnit || 'm'}`
+          : '--';
+  const elevation =
+    workout.run?.elevationGain
+      ? `${workout.run.elevationGain}m`
+      : workout.bike?.elevationGain
+        ? `${workout.bike.elevationGain}m`
+        : workout.stravaData?.elevationGain
+          ? `${workout.stravaData.elevationGain}m`
+          : '--';
+  const avgHR =
+    workout.run?.avgHeartRate
+      ? `${workout.run.avgHeartRate}`
+      : workout.bike?.avgHeartRate
+        ? `${workout.bike.avgHeartRate}`
+        : workout.stravaData?.avgHeartRate
+          ? `${workout.stravaData.avgHeartRate}`
+          : '--';
+  const maxHR = workout.stravaData?.maxHeartRate
+    ? `${workout.stravaData.maxHeartRate}`
+    : '--';
+
+  return (
+    <div className="w-[380px] shrink-0 border-l bg-card overflow-y-auto flex flex-col">
+      {/* Header */}
+      <div className="sticky top-0 z-10 bg-card border-b px-4 py-3 flex items-start justify-between gap-2">
+        <div className="min-w-0">
+          <p className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
+            {format(workoutDate, 'EEE, MMM d')} | {TYPE_LABELS[workout.type] || workout.type}
+          </p>
+          <h2 className="text-base font-bold truncate mt-0.5">{workout.name}</h2>
+        </div>
+        <button
+          onClick={onClose}
+          className="p-1.5 rounded-lg hover:bg-muted transition-colors shrink-0"
+        >
+          <X className="h-4 w-4" />
+        </button>
+      </div>
+
+      <div className="p-4 space-y-4">
+        {/* Source badge */}
+        {isStrava && (
+          <div className="flex items-center gap-1.5">
+            <span className="inline-flex items-center gap-1 px-2 py-1 rounded-md text-xs font-bold bg-orange-500/10 text-orange-600 border border-orange-500/20">
+              <Activity className="h-3.5 w-3.5" />
+              STRAVA
+            </span>
+          </div>
+        )}
+
+        {/* Route map */}
+        {hasRoute && (
+          <MiniRoutePreview
+            polyline={workout.routeData!.polyline!}
+            width={350}
+            height={180}
+            strokeWidth={2.5}
+            className="rounded-xl"
+          />
+        )}
+
+        {/* Key stats grid */}
+        <div className="grid grid-cols-2 gap-3">
+          <StatBlock icon={<Clock className="h-4 w-4" />} label="Duration" value={duration} />
+          <StatBlock icon={<MapPin className="h-4 w-4" />} label="Distance" value={distance} />
+          <StatBlock icon={<Mountain className="h-4 w-4" />} label="Elevation Gain" value={elevation} />
+          <StatBlock icon={<Heart className="h-4 w-4" />} label="Avg HR" value={avgHR !== '--' ? `${avgHR} bpm` : '--'} />
+          {maxHR !== '--' && (
+            <StatBlock icon={<Zap className="h-4 w-4" />} label="Max HR" value={`${maxHR} bpm`} />
+          )}
+          {workout.bike?.avgPower && (
+            <StatBlock icon={<Zap className="h-4 w-4" />} label="Avg Power" value={`${workout.bike.avgPower}W`} />
+          )}
+        </div>
+
+        {/* Status */}
+        <div className="flex items-center gap-2 text-sm">
+          {workout.completed && !workout.completedLate && (
+            <span className="flex items-center gap-1.5 text-green-600 font-semibold">
+              <CheckCircle2 className="h-4 w-4" /> Completed
+            </span>
+          )}
+          {workout.completedLate && (
+            <span className="flex items-center gap-1.5 text-amber-600 font-semibold">
+              <CheckCircle2 className="h-4 w-4" /> Completed Late
+            </span>
+          )}
+          {isMissed && (
+            <span className="flex items-center gap-1.5 text-red-500 font-semibold">
+              <Circle className="h-4 w-4" /> Missed
+            </span>
+          )}
+          {!workout.completed && !isMissed && (
+            <span className="flex items-center gap-1.5 text-blue-600 font-semibold">
+              <Circle className="h-4 w-4" /> Planned
+            </span>
+          )}
+        </div>
+
+        {/* Tags */}
+        {workout.tags && workout.tags.length > 0 && (
+          <div className="flex flex-wrap gap-1.5">
+            {workout.tags.map((tag) => (
+              <span
+                key={tag}
+                className="px-2 py-0.5 rounded-full text-xs font-medium capitalize bg-muted border"
+              >
+                {tag}
+              </span>
+            ))}
+          </div>
+        )}
+
+        {/* Description */}
+        {workout.description && (
+          <div>
+            <h4 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground mb-1">
+              Description
+            </h4>
+            <p className="text-sm text-muted-foreground leading-relaxed">
+              {workout.description}
+            </p>
+          </div>
+        )}
+
+        {/* Completion notes */}
+        {workout.completionNotes && (
+          <div className="bg-muted/40 rounded-lg p-3">
+            <h4 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground mb-1">
+              Notes
+            </h4>
+            <p className="text-sm italic text-muted-foreground">
+              &ldquo;{workout.completionNotes}&rdquo;
+            </p>
+          </div>
+        )}
+
+        {/* Photos */}
+        {workout.photos && workout.photos.length > 0 && (
+          <WorkoutPhotos photos={workout.photos} className="mt-2" />
+        )}
+
+        {/* Actions */}
+        <div className="flex items-center gap-2 pt-2 border-t">
+          {onToggleComplete && (
+            <button
+              onClick={(e) => onToggleComplete(e, workout)}
+              className={cn(
+                'flex-1 flex items-center justify-center gap-2 px-4 py-2 rounded-lg text-sm font-semibold transition-colors',
+                workout.completed
+                  ? 'border hover:bg-muted'
+                  : 'bg-green-600 text-white hover:bg-green-700',
+              )}
+            >
+              {workout.completed ? (
+                <>
+                  <Circle className="h-4 w-4" /> Undo
+                </>
+              ) : (
+                <>
+                  <CheckCircle2 className="h-4 w-4" /> Complete
+                </>
+              )}
+            </button>
+          )}
+          <Link
+            href={`/workouts/${workout.id}`}
+            className="flex items-center gap-1.5 px-4 py-2 rounded-lg text-sm font-semibold border hover:bg-muted transition-colors"
+          >
+            <ExternalLink className="h-3.5 w-3.5" />
+            Details
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function StatBlock({
+  icon,
+  label,
+  value,
+}: {
+  icon: React.ReactNode;
+  label: string;
+  value: string;
+}) {
+  return (
+    <div className="bg-muted/30 rounded-lg px-3 py-2.5">
+      <div className="flex items-center gap-1.5 text-muted-foreground mb-1">
+        {icon}
+        <span className="text-[10px] font-semibold uppercase tracking-wider">{label}</span>
+      </div>
+      <div className="text-lg font-black">{value}</div>
+    </div>
+  );
+}

--- a/src/components/calendar/types.ts
+++ b/src/components/calendar/types.ts
@@ -1,0 +1,86 @@
+import { Workout } from '@/types';
+
+// ── Type configuration (colors, emoji per workout type) ──────────────────
+export const TYPE_CONFIG: Record<string, { emoji: string; color: string; border: string; bg: string }> = {
+  run: { emoji: '🏃', color: 'text-red-500', border: 'border-l-red-500', bg: 'bg-red-500/8' },
+  bike: { emoji: '🚴', color: 'text-amber-500', border: 'border-l-amber-500', bg: 'bg-amber-500/8' },
+  swim: { emoji: '🏊', color: 'text-cyan-500', border: 'border-l-cyan-500', bg: 'bg-cyan-500/8' },
+  strength: { emoji: '💪', color: 'text-purple-500', border: 'border-l-purple-500', bg: 'bg-purple-500/8' },
+  other: { emoji: '📋', color: 'text-gray-400', border: 'border-l-gray-400', bg: 'bg-gray-500/8' },
+};
+
+// ── Stat extraction ──────────────────────────────────────────────────────
+export function getTypeData(w: Workout): Record<string, string> {
+  const d: Record<string, string> = {};
+
+  if (w.type === 'run' && w.run) {
+    d.primary = w.run.distance ? `${w.run.distance} ${w.run.distanceUnit || 'km'}` : '--';
+    d.primaryLabel = 'DISTANCE';
+    d.time = w.run.time ? formatDur(w.run.time) : (w.duration ? formatDur(w.duration) : '0:00');
+    d.hr = w.run.avgHeartRate ? `${w.run.avgHeartRate}` : '--';
+    d.hrLabel = 'AVG HR';
+    d.stat4 = w.run.elevationGain ? `${w.run.elevationGain}m` : (w.run.pace ? `${w.run.pace}` : '--');
+    d.stat4Label = w.run.elevationGain ? 'ELEV' : 'PACE';
+  } else if (w.type === 'bike' && w.bike) {
+    d.primary = w.bike.distance ? `${w.bike.distance} ${w.bike.distanceUnit || 'km'}` : '--';
+    d.primaryLabel = 'DISTANCE';
+    d.time = w.bike.time ? formatDur(w.bike.time) : (w.duration ? formatDur(w.duration) : '0:00');
+    d.hr = w.bike.avgHeartRate ? `${w.bike.avgHeartRate}` : '--';
+    d.hrLabel = 'AVG HR';
+    d.stat4 = w.bike.elevationGain ? `${w.bike.elevationGain}m` : '--';
+    d.stat4Label = 'ELEV';
+  } else if (w.type === 'swim' && w.swim) {
+    d.primary = w.swim.distance ? `${w.swim.distance} ${w.swim.distanceUnit || 'm'}` : '--';
+    d.primaryLabel = 'DISTANCE';
+    d.time = w.swim.time ? formatDur(w.swim.time) : (w.duration ? formatDur(w.duration) : '0:00');
+    d.hr = '--';
+    d.hrLabel = 'AVG HR';
+    d.stat4 = '--';
+    d.stat4Label = 'PACE';
+  } else if (w.type === 'strength' && w.strength) {
+    const exCount = w.strength.exercises?.length || 0;
+    const totalSets = w.strength.exercises?.reduce((sum, ex) => sum + (ex.sets || 0), 0) || 0;
+    d.primary = totalSets > 0 ? `${totalSets} Sets` : (exCount > 0 ? `${exCount} Ex` : '--');
+    d.primaryLabel = totalSets > 0 ? 'TOTAL SETS' : 'EXERCISES';
+    d.time = w.duration ? formatDur(w.duration) : '0:00';
+    d.hr = '--';
+    d.hrLabel = 'AVG HR';
+    d.stat4 = '--';
+    d.stat4Label = 'CALORIES';
+  } else {
+    d.primary = '--';
+    d.primaryLabel = 'DISTANCE';
+    d.time = w.duration ? formatDur(w.duration) : '0:00';
+    d.hr = '--';
+    d.hrLabel = 'AVG HR';
+    d.stat4 = '--';
+    d.stat4Label = '';
+  }
+  d.timeLabel = 'TIME';
+  return d;
+}
+
+// ── Duration formatters ──────────────────────────────────────────────────
+export function formatDur(mins: number): string {
+  const h = Math.floor(mins / 60);
+  const m = Math.round(mins % 60);
+  if (h === 0) return `${m}min`;
+  return `${h}:${m.toString().padStart(2, '0')}`;
+}
+
+export function formatDurLong(mins: number): string {
+  const h = Math.floor(mins / 60);
+  const m = Math.round(mins % 60);
+  if (h === 0) return `${m} min`;
+  if (m === 0) return `${h}h`;
+  return `${h}h ${m}m`;
+}
+
+// ── Readable type labels ─────────────────────────────────────────────────
+export const TYPE_LABELS: Record<string, string> = {
+  run: 'Running',
+  bike: 'Cycling',
+  swim: 'Swimming',
+  strength: 'Strength Training',
+  other: 'Other',
+};


### PR DESCRIPTION
## Summary
- Redesign calendar from 7-column weekly grid to **monthly calendar grid** (desktop) with **workout detail panel** on the right
- Add **horizontal week strip** (mobile) with day workout list, source badges, and "+ Add Plan" button
- Decompose 510-line monolith into 8 focused components under `src/components/calendar/`

## Changes
**New components:**
- `CalendarMonthView` — Desktop monthly grid with workout mini-pills in cells, today highlight, selected cell ring
- `MobileWeekStrip` — Horizontal week selector with active day, workout type dots, swipe navigation
- `WorkoutDetailPanel` — Right panel (380px) with route map, stats grid (duration/distance/elevation/HR), source badges, completion actions
- `CalendarDayWorkouts` — Mobile day list with planned/done/missed badges, rest day state, "+ Add Plan"
- `CalendarHeader` — Month navigation, "Add Workout" button, type filter pills, coach athlete picker, mobile overflow dropdown
- `CalendarWorkoutCard` — Dual-mode: mini-pill (month grid) + compact card (mobile list)
- `CalendarSummary` — Extracted responsive weekly summary bar
- `types.ts` — Shared TYPE_CONFIG, getTypeData, formatDur helpers

**Refactored:** `calendar/page.tsx` → orchestrator with responsive layout composition and pre-computed `workoutsByDate` map

## Test plan
- [ ] Desktop: monthly grid shows workout pills, clicking a pill opens detail panel with stats + map
- [ ] Desktop: month navigation, "Today" button, filter pills, coach athlete picker all work
- [ ] Mobile (<768px): week strip shows 7 days, tapping day shows workouts below
- [ ] Mobile: "+ Add Plan" links to workout creation with pre-filled date
- [ ] Strava sync banner shows on both layouts
- [ ] Completion toggle works from grid pill, mobile card, and detail panel
- [ ] Export ICS and email report still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)