### PR TITLE
Fix: user.uid vs user.username mismatches across codebase

### DIFF
--- a/src/app/(dashboard)/workouts/[id]/edit/page.tsx
+++ b/src/app/(dashboard)/workouts/[id]/edit/page.tsx
@@ -113,7 +113,7 @@ export default function EditWorkoutPage() {
       }
 
       // Verify ownership
-      if (workoutData.createdBy !== user.uid) {
+      if (workoutData.createdBy !== user.username) {
         toast.error('You can only edit your own workouts');
         router.push('/workouts');
         return;

--- a/src/app/(dashboard)/workouts/[id]/page.tsx
+++ b/src/app/(dashboard)/workouts/[id]/page.tsx
@@ -151,7 +151,7 @@ export default function WorkoutDetailPage() {
           duration: workout.duration,
           timeframe: timeframe || null,
           frequency: frequency || null,
-          createdBy: user.uid,
+          createdBy: user.username,
           workoutId: workout.id, // Track which workout created this template
         }),
       });
@@ -186,7 +186,7 @@ export default function WorkoutDetailPage() {
     setIsSavingTemplate(true);
     try {
       const response = await fetch(
-        `/api/templates?templateId=${workout.templateId}&userId=${user.uid}`,
+        `/api/templates?templateId=${workout.templateId}&userId=${user.username}`,
         {
           method: 'DELETE',
         }
@@ -229,7 +229,7 @@ export default function WorkoutDetailPage() {
 
   if (!user || !workout) return null;
 
-  const canEdit = user.role === 'coach' && workout.createdBy === user.uid;
+  const canEdit = user.role === 'coach' && workout.createdBy === user.username;
   const isPastWorkout = workout.date.toDate() < new Date();
   const isMissed = isPastWorkout && !workout.completed;
   const isAthlete = user.role === 'athlete' || user.role === 'student';
@@ -479,7 +479,7 @@ export default function WorkoutDetailPage() {
         workoutId={workout.id}
         workoutName={workout.name}
         ownerUsername={workout.ownerUsername}
-        currentUserId={user.uid}
+        currentUserId={user.username}
         currentUserName={user.displayName}
         currentUserRole={user.role}
         coachId={workout.createdBy}

--- a/src/components/onboarding/OnboardingModal.tsx
+++ b/src/components/onboarding/OnboardingModal.tsx
@@ -53,7 +53,7 @@ export function OnboardingModal() {
 
     setSaving(true);
     try {
-      const userRef = doc(getDbInstance(), 'users', user.uid);
+      const userRef = doc(getDbInstance(), 'users', user.username);
       await updateDoc(userRef, {
         displayName: trimmed,
         onboardingCompleted: true,

--- a/src/components/workouts/WorkoutPreview.tsx
+++ b/src/components/workouts/WorkoutPreview.tsx
@@ -58,7 +58,7 @@ export function WorkoutPreview({ workout, workoutId }: WorkoutPreviewProps) {
       const res = await fetch('/api/workouts/copy', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ workoutId, userId: user.uid }),
+        body: JSON.stringify({ workoutId, userId: user.username }),
       });
       if (!res.ok) throw new Error('Failed to copy workout');
       toast.success('Workout added to your list!');


### PR DESCRIPTION
## Summary
Full audit found 6 more places where `user.uid` (Firebase Auth UID) was used instead of `user.username` (Firestore doc key):

| File | Bug |
|------|-----|
| `OnboardingModal.tsx` | Firestore doc path `users/{uid}` → should be `users/{username}` |
| `workouts/[id]/page.tsx` | `canEdit` check always false (comparing username field vs UID) |
| `workouts/[id]/page.tsx` | Template `createdBy` set to UID instead of username |
| `workouts/[id]/page.tsx` | Template delete sends UID for ownership check |
| `workouts/[id]/page.tsx` | Comments store UID as userId |
| `workouts/[id]/edit/page.tsx` | Edit auth check always blocks coaches |
| `WorkoutPreview.tsx` | Copy endpoint sends UID |

## Impact
- Coaches could never edit their own workouts (canEdit always false)
- Onboarding display name update wrote to wrong Firestore document
- Template save/unsave used wrong identifier

🤖 Generated with [Claude Code](https://claude.com/claude-code)