### PR TITLE
Fix: only allow completing planned workouts, not Strava

### DIFF
--- a/src/app/(dashboard)/workouts/[id]/page.tsx
+++ b/src/app/(dashboard)/workouts/[id]/page.tsx
@@ -421,8 +421,8 @@ export default function WorkoutDetailPage() {
             </div>
           )}
 
-          {/* Completion button - only show for athletes */}
-          {isAthlete ? (
+          {/* Completion button - only show for planned workouts (not Strava) */}
+          {workout.source === 'strava' ? null : isAthlete ? (
             <Button
               onClick={() =>
                 workout.completed

--- a/src/components/calendar/CalendarWorkoutCard.tsx
+++ b/src/components/calendar/CalendarWorkoutCard.tsx
@@ -148,7 +148,7 @@ function CompactCard({
               <Activity className="h-3 w-3" />S
             </span>
           )}
-          {onToggleComplete && (
+          {onToggleComplete && workout.source !== 'strava' && (
             <button
               onClick={(e) => onToggleComplete(e, workout)}
               className="opacity-40 hover:opacity-100 transition-opacity"

--- a/src/components/calendar/WorkoutDetailPanel.tsx
+++ b/src/components/calendar/WorkoutDetailPanel.tsx
@@ -193,7 +193,7 @@ export function WorkoutDetailPanel({
 
         {/* Actions */}
         <div className="flex items-center gap-2 pt-2 border-t">
-          {onToggleComplete && (
+          {onToggleComplete && workout.source !== 'strava' && (
             <button
               onClick={(e) => onToggleComplete(e, workout)}
               className={cn(

--- a/src/components/workouts/WorkoutCard.tsx
+++ b/src/components/workouts/WorkoutCard.tsx
@@ -221,7 +221,7 @@ export function WorkoutCard({ workout, onEdit, onDelete, onToggleComplete, onVie
 
           {hasActions && (
             <div className="flex items-center gap-2 pt-2 border-t border-border/50">
-              {onToggleComplete && (
+              {onToggleComplete && workout.source !== 'strava' && (
                 <Button variant={workout.completed ? 'outline' : 'default'} size="sm" onClick={handleCompletionClick} className={cn('flex-1 h-9', !workout.completed && 'bg-green-600 hover:bg-green-700')}>
                   {workout.completed ? <><Circle className="h-4 w-4 mr-1.5" />Undo</> : <><CheckCircle2 className="h-4 w-4 mr-1.5" />Complete</>}
                 </Button>


### PR DESCRIPTION
## Summary
- Hide the Complete/Undo button for Strava-synced workouts (`source === 'strava'`)
- Strava workouts are already completed by nature — they represent actual activities
- Applied across all 4 UI locations: WorkoutCard, CalendarWorkoutCard, WorkoutDetailPanel, workout detail page

🤖 Generated with [Claude Code](https://claude.com/claude-code)