### PR TITLE
Monthly Review: visual overhaul + proper calendar + bug fix

### DIFF
--- a/src/app/(dashboard)/calendar/page.tsx
+++ b/src/app/(dashboard)/calendar/page.tsx
@@ -229,7 +229,7 @@ export default function CalendarPage() {
   const handleToday = () => {
     const now = new Date();
     setCurrentMonth(now);
-    setWeekStart(startOfWeek(now, { weekStartsOn: 1 }));
+    setWeekStart(startOfWeek(now, { weekStartsOn: 0 }));
     setSelectedDate(now);
   };
 

--- a/src/app/(dashboard)/review/page.tsx
+++ b/src/app/(dashboard)/review/page.tsx
@@ -17,6 +17,7 @@ import {
 } from 'recharts';
 import { Share2, Loader2, ChevronLeft, ChevronRight, X, TrendingUp, TrendingDown, Minus, Instagram, Calendar, Clock, Flame, MapPin } from 'lucide-react';
 import Link from 'next/link';
+import { cn } from '@/lib/utils';
 import { ThemeToggle } from '@/components/dashboard/ThemeToggle';
 import { toPng } from 'html-to-image';
 import { toast } from 'sonner';
@@ -118,46 +119,51 @@ function pctChange(curr: number, prev: number): { text: string; positive: boolea
 function ActivityCalendar({ days, monthStart }: { days: { date: Date; count: number }[]; monthStart: Date }) {
   const firstDayOfWeek = getDay(monthStart); // 0=Sun
   const blanks = Array.from({ length: firstDayOfWeek });
+  const today = new Date();
+
   return (
     <div>
-      <div className="grid grid-cols-7 gap-1 mb-1">
+      {/* Day-of-week headers */}
+      <div className="grid grid-cols-7 gap-px mb-1">
         {DAY_LABELS.map((d, i) => (
-          <div key={i} className="text-[9px] text-muted-foreground/50 text-center font-medium">{d}</div>
+          <div key={i} className="text-[10px] text-muted-foreground/60 text-center font-semibold py-1">{d}</div>
         ))}
       </div>
-      <div className="grid grid-cols-7 gap-1">
-        {blanks.map((_, i) => <div key={`b-${i}`} className="aspect-square" />)}
-        {days.map((d, i) => {
-          const intensity = d.count === 0 ? 0 : d.count === 1 ? 1 : d.count === 2 ? 2 : 3;
-          const bg = intensity === 0
-            ? 'bg-muted/30'
-            : intensity === 1
-              ? 'bg-emerald-500/30'
-              : intensity === 2
-                ? 'bg-emerald-500/60'
-                : 'bg-emerald-500';
+      {/* Calendar grid */}
+      <div className="grid grid-cols-7 gap-px">
+        {blanks.map((_, i) => <div key={`b-${i}`} className="h-9" />)}
+        {days.map((d) => {
+          const isToday = isSameDay(d.date, today);
+          const active = d.count > 0;
           return (
             <div
-              key={i}
-              className={`aspect-square rounded-[3px] ${bg} transition-colors relative group`}
+              key={format(d.date, 'd')}
+              className={cn(
+                'h-9 flex flex-col items-center justify-center rounded-lg relative transition-colors',
+                active
+                  ? 'bg-emerald-500/15'
+                  : 'bg-transparent',
+                isToday && 'ring-1 ring-primary/50',
+              )}
               title={`${format(d.date, 'MMM d')}: ${d.count} workout${d.count !== 1 ? 's' : ''}`}
             >
-              {d.count > 0 && (
-                <div className="absolute inset-0 flex items-center justify-center">
-                  <span className="text-[8px] font-bold text-white/80">{d.count}</span>
+              <span className={cn(
+                'text-xs font-semibold leading-none',
+                active ? 'text-emerald-600 dark:text-emerald-400' : 'text-muted-foreground/60',
+                isToday && 'text-primary',
+              )}>
+                {format(d.date, 'd')}
+              </span>
+              {active && (
+                <div className="flex items-center gap-0.5 mt-0.5">
+                  {Array.from({ length: Math.min(d.count, 3) }).map((_, i) => (
+                    <div key={i} className="w-1 h-1 rounded-full bg-emerald-500" />
+                  ))}
                 </div>
               )}
             </div>
           );
         })}
-      </div>
-      <div className="flex items-center gap-1.5 mt-2 justify-end">
-        <span className="text-[8px] text-muted-foreground/50">Less</span>
-        <div className="w-2.5 h-2.5 rounded-[2px] bg-muted/30" />
-        <div className="w-2.5 h-2.5 rounded-[2px] bg-emerald-500/30" />
-        <div className="w-2.5 h-2.5 rounded-[2px] bg-emerald-500/60" />
-        <div className="w-2.5 h-2.5 rounded-[2px] bg-emerald-500" />
-        <span className="text-[8px] text-muted-foreground/50">More</span>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- **Visual overhaul** of the Monthly Review page (`/review`): gradient hero banner, colored stat cards with icons, sport-specific gradient rows, highlight section, wide 3-column layout
- **Activity calendar** is now an actual calendar grid with date numbers, day-of-week headers (S M T W T F S), and green dot indicators for workout days — replacing the old GitHub-style heatmap
- **"Not ready" gate** for current/future months — shows a friendly message with a button to view the previous month instead
- **Instagram Story export** via `html-to-image` at 1080×1920 with dark gradient template
- **Bug fix**: `handleToday` in calendar page used `weekStartsOn: 1` while all other week calculations use `0` — now consistent

## Test plan
- [ ] Navigate to `/review` — verify current month shows "not over yet" gate
- [ ] Click "View last month" — verify full review loads with calendar, charts, stats
- [ ] Verify activity calendar shows correct day alignment (e.g., if March 1 is a Sunday, "1" appears under "S")
- [ ] Test "Insta Story" export downloads a PNG
- [ ] Test "Share" button opens share options
- [ ] Verify calendar page "Today" button snaps to correct week (weekStartsOn: 0)
- [ ] Check dark mode — all sections should look correct in both themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)