### PR TITLE
Fix share image capture failures

### DIFF
--- a/src/app/(dashboard)/review/page.tsx
+++ b/src/app/(dashboard)/review/page.tsx
@@ -455,7 +455,7 @@ export default function MonthlyReviewPage() {
                 {highlight.photo && (
                   <div className="h-20 overflow-hidden">
                     {/* eslint-disable-next-line @next/next/no-img-element */}
-                    <img src={highlight.photo} alt="" className="w-full h-full object-cover" />
+                    <img src={highlight.photo} alt="" className="w-full h-full object-cover" crossOrigin="anonymous" />
                   </div>
                 )}
                 <div className="p-3">

--- a/src/components/workouts/ShareWorkoutCard.tsx
+++ b/src/components/workouts/ShareWorkoutCard.tsx
@@ -62,7 +62,32 @@ function ShareButtons({ title, shareText, shareUrl, fileName, cardRef, onClose, 
     if (!cardRef.current) return null;
     setIsGenerating(true);
     try {
-      return await toPng(cardRef.current, { quality: 0.95, pixelRatio: 2, ...(captureBg ? { backgroundColor: captureBg } : {}) });
+      // Try up to 3 times — html-to-image can be flaky on first attempt
+      for (let attempt = 0; attempt < 3; attempt++) {
+        try {
+          return await toPng(cardRef.current, {
+            quality: 0.95,
+            pixelRatio: 2,
+            cacheBust: true,
+            skipFonts: true,
+            includeQueryParams: true,
+            imagePlaceholder: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==',
+            ...(captureBg ? { backgroundColor: captureBg } : {}),
+            filter: (node: HTMLElement) => {
+              // Skip cross-origin images that cause CORS failures
+              if (node.tagName === 'IMG') {
+                const src = (node as HTMLImageElement).src || '';
+                if (src && !src.startsWith('data:') && !src.startsWith(window.location.origin)) return false;
+              }
+              return true;
+            },
+          });
+        } catch {
+          if (attempt === 2) throw new Error('Image generation failed after retries');
+          await new Promise(r => setTimeout(r, 300));
+        }
+      }
+      return null;
     } catch (err) {
       console.error('Failed to generate image:', err);
       toast.error('Failed to generate share image');


### PR DESCRIPTION
## Summary
- Fix `html-to-image` `toPng` failing with "Event" error on the review page
- Cross-origin images (Strava photos) were causing CORS failures during DOM serialization
- Added `skipFonts`, `cacheBust`, `imagePlaceholder` options to handle edge cases
- Added filter to exclude cross-origin `<img>` elements from capture
- Added retry logic (3 attempts with 300ms delay) since html-to-image can be flaky
- Added `crossOrigin="anonymous"` to highlight photo element

## Test plan
- [ ] Open /review, click Share → Instagram Story — image should generate successfully
- [ ] Verify Save Image button works without "Failed to generate image" errors
- [ ] Build passes ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)