### PR TITLE
Fix AI workout suggestions: truncation + preview display

### DIFF
--- a/src/app/api/ai/workout-suggestions/route.ts
+++ b/src/app/api/ai/workout-suggestions/route.ts
@@ -17,21 +17,37 @@ const MAX_RETRIES = 1;
 
 function buildFallback(logicOutput: LogicOutput): EnhancedWorkout[] {
   const { plan, athlete } = logicOutput;
-  return plan.map((p) => ({
-    ...p,
-    name: `${p.intensity.charAt(0).toUpperCase() + p.intensity.slice(1)} ${p.type.charAt(0).toUpperCase() + p.type.slice(1)} Session`,
-    description: `${athlete.deload ? '[DELOAD] ' : ''}A ${p.intensity} ${p.type} session focused on ${p.focus}.${athlete.phase !== 'general' ? ` (${athlete.phase} phase${athlete.weeksOut ? `, ${athlete.weeksOut}w to event` : ''})` : ''}`,
-    rationale: '',
-    benefits: [],
-    tags: [p.intensity],
-    warmup: '',
-    mainSet: '',
-    cooldown: '',
-    sessionType: p.focus,
-    aiModified: false,
-    changesCount: 0,
-    loadDeltaPercent: 0,
-  }));
+  return plan.map((p) => {
+    const capIntensity = p.intensity.charAt(0).toUpperCase() + p.intensity.slice(1);
+    const capType = p.type.charAt(0).toUpperCase() + p.type.slice(1);
+    const capFocus = p.focus.charAt(0).toUpperCase() + p.focus.slice(1);
+
+    // Build basic warmup/mainSet/cooldown per type
+    const warmup = p.type === 'strength'
+      ? '5-10 min light cardio, dynamic stretches'
+      : `10 min easy ${p.type}, dynamic stretches`;
+    const cooldown = p.type === 'strength'
+      ? '5 min light cardio, static stretches'
+      : `5-10 min easy ${p.type}, static stretching`;
+    const mainDur = Math.max(p.durationMin - 15, 10);
+    const mainSet = `${mainDur} min ${p.intensity} ${p.focus}`;
+
+    return {
+      ...p,
+      name: `${capIntensity} ${capType} — ${capFocus}`,
+      description: `${athlete.deload ? '[DELOAD] ' : ''}A ${p.intensity} ${p.type} session focused on ${p.focus}. ${p.durationMin} minutes total.${athlete.phase !== 'general' ? ` (${athlete.phase} phase${athlete.weeksOut ? `, ${athlete.weeksOut}w to event` : ''})` : ''}`,
+      rationale: `Planned based on your training history and ${athlete.phase} phase.`,
+      benefits: [`Develops ${p.focus}`, `Maintains ${p.type} fitness`],
+      tags: [p.intensity],
+      warmup,
+      mainSet,
+      cooldown,
+      sessionType: p.focus,
+      aiModified: false,
+      changesCount: 0,
+      loadDeltaPercent: 0,
+    };
+  });
 }
 
 /* ── Build GROQ prompt ────────────────────────────────────────────────── */
@@ -267,7 +283,7 @@ export async function POST(request: NextRequest) {
             { role: 'user', content: userMsg },
           ],
           temperature: attempt === 0 ? 0.7 : 0.4, // lower temp on retry
-          max_tokens: 3000,
+          max_tokens: 8000,
           response_format: { type: 'json_object' },
         });
 

--- a/src/components/workouts/WorkoutPreviewDialog.tsx
+++ b/src/components/workouts/WorkoutPreviewDialog.tsx
@@ -48,6 +48,7 @@ export function WorkoutPreviewDialog({ open, onClose, onConfirm, data, athleteNa
     if (typeData.time) stats.push({ label: 'Duration', value: `${typeData.time} min` });
     if (typeData.pace) stats.push({ label: 'Target Pace', value: `${typeData.pace} /km` });
     if (typeData.terrain) stats.push({ label: 'Terrain', value: typeData.terrain });
+    if (typeData.elevationGain) stats.push({ label: 'Elevation', value: `${typeData.elevationGain}m` });
   } else if (data.type === 'swim' && typeData) {
     if (typeData.distance) stats.push({ label: 'Distance', value: `${typeData.distance} m` });
     if (typeData.time) stats.push({ label: 'Duration', value: `${typeData.time} min` });
@@ -57,11 +58,15 @@ export function WorkoutPreviewDialog({ open, onClose, onConfirm, data, athleteNa
     if (typeData.distance) stats.push({ label: 'Distance', value: `${typeData.distance} ${typeData.distanceUnit || 'km'}` });
     if (typeData.time) stats.push({ label: 'Duration', value: `${typeData.time} min` });
     if (typeData.terrain) stats.push({ label: 'Terrain', value: typeData.terrain });
+    if (typeData.elevationGain) stats.push({ label: 'Elevation', value: `${typeData.elevationGain}m` });
   } else if (data.type === 'strength' && typeData) {
-    if (typeData.exercises) stats.push({ label: 'Exercises', value: String(typeData.exercises) });
-    if (typeData.sets) stats.push({ label: 'Sets', value: String(typeData.sets) });
-    if (typeData.reps) stats.push({ label: 'Reps', value: String(typeData.reps) });
-    if (typeData.duration) stats.push({ label: 'Duration', value: `${typeData.duration} min` });
+    if (Array.isArray(typeData.exercises) && typeData.exercises.length > 0) {
+      stats.push({ label: 'Exercises', value: `${typeData.exercises.length} exercises` });
+      const totalSets = typeData.exercises.reduce((s: number, e: any) => s + (e.sets || 0), 0);
+      if (totalSets > 0) stats.push({ label: 'Total Sets', value: String(totalSets) });
+    }
+    if (typeData.totalTime) stats.push({ label: 'Duration', value: `${typeData.totalTime} min` });
+    if (typeData.rpe) stats.push({ label: 'RPE', value: `${typeData.rpe}/10` });
   }
 
   return (
@@ -107,6 +112,21 @@ export function WorkoutPreviewDialog({ open, onClose, onConfirm, data, athleteNa
             <div className="rounded-xl border bg-card p-4">
               <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-2">Details</p>
               {stats.map(s => <StatRow key={s.label} label={s.label} value={s.value} />)}
+            </div>
+          )}
+
+          {/* Strength Exercises List */}
+          {data.type === 'strength' && typeData?.exercises && Array.isArray(typeData.exercises) && typeData.exercises.length > 0 && (
+            <div className="rounded-xl border bg-card p-4">
+              <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-2">Exercises</p>
+              {typeData.exercises.map((ex: any, i: number) => (
+                <div key={i} className="flex justify-between py-1.5 border-b border-border/50 last:border-0">
+                  <span className="text-sm font-medium">{ex.name}</span>
+                  <span className="text-sm text-muted-foreground">
+                    {ex.sets}×{ex.reps}{ex.weight ? ` @ ${ex.weight}${ex.weightUnit || 'kg'}` : ''}
+                  </span>
+                </div>
+              ))}
             </div>
           )}
 


### PR DESCRIPTION
## Summary
- **Increased GROQ `max_tokens` from 3000 → 8000** to prevent JSON truncation that caused AI workouts to silently fall back to empty logic-only defaults (root cause of "workout details literally cut off")
- **Improved fallback workouts** with meaningful names, descriptions, warmup/mainSet/cooldown instead of empty strings
- **Fixed strength workout preview** — was showing `[object Object]` for exercises and referencing non-existent `sets`/`reps` fields; now properly shows exercise count, total sets, RPE, and individual exercise list
- **Added elevation gain** display for run and bike previews

## Test plan
- [ ] Generate AI workout suggestions and verify all fields (name, description, warmup, mainSet, cooldown, specs) are populated
- [ ] Click "Use Workout" on a strength workout → preview shows exercises list with sets×reps
- [ ] Click "Use Workout" on a run/bike → preview shows elevation if present
- [ ] Form is pre-filled with all AI data after clicking through preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)