### PR TITLE
Fix AI workout form: type not selecting & details cut off

### DIFF
--- a/src/app/(dashboard)/workouts/new/page.tsx
+++ b/src/app/(dashboard)/workouts/new/page.tsx
@@ -230,10 +230,19 @@ export default function NewWorkoutPage() {
 
   const formDefaultValues = useMemo(() => {
     if (templateData) {
+      // Safely parse date — AI sends "YYYY-MM-DD", templates may send ISO strings
+      let parsedDate = new Date();
+      try {
+        if (templateData.date) {
+          const d = new Date(templateData.date);
+          if (!isNaN(d.getTime())) parsedDate = d;
+        }
+      } catch { /* use default */ }
+
       return {
-        name: templateData.name,
+        name: templateData.name || '',
         type: templateData.type,
-        date: templateData.date ? new Date(templateData.date + 'T00:00:00') : new Date(),
+        date: parsedDate,
         description: templateData.description
           || [templateData.warmup, templateData.mainSet, templateData.cooldown].filter(Boolean).join('\n\n')
           || '',
@@ -272,6 +281,7 @@ export default function NewWorkoutPage() {
         </CardHeader>
         <CardContent>
           <WorkoutForm
+            key={templateData ? `template-${templateData.type}-${templateData.name}` : 'blank'}
             onSubmit={handleSubmit}
             athletes={students}
             loading={loading || loadingTemplate}


### PR DESCRIPTION
## Summary
- **Force WorkoutForm remount** via `key` prop when AI/template data loads — ensures the type Select initializes correctly and the matching sub-form (RunForm, BikeForm, etc.) renders
- **Fix date parsing** — safely handles various date formats from AI (`YYYY-MM-DD`) and templates (ISO strings) with try/catch + `isNaN` validation instead of brittle string concatenation

## Problem
After PR #38 fixed the AI truncation and preview display, the workout creation form still didn't populate correctly:
- Type dropdown showed "Select type" placeholder instead of the actual workout type
- Type-specific details section was empty (sub-form didn't render)

## Root Cause
`react-hook-form`'s `reset()` doesn't reliably sync with Radix UI's controlled Select component. The form initialized with fallback defaults before AI data loaded from sessionStorage, and subsequent `reset()` calls didn't update the Select state.

## Test plan
- [ ] Generate AI workouts → click "Use Workout" → verify type dropdown shows correct type
- [ ] Verify type-specific sub-form renders with pre-filled data (distance, time, etc.)
- [ ] Test with each workout type (run, bike, swim, strength)
- [ ] Test template-based workout creation still works
- [ ] Test blank workout creation still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)