### PR TITLE
Fix milestone dates showing Dec 31, 1969

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -119,7 +119,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -580,7 +579,6 @@
       "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.14.8.tgz",
       "integrity": "sha512-WiE9uCGRLUnShdjb9iP20sA3ToWrBbNXr14/N5mow7Nls9dmKgfGaGX5cynLvrltxq2OrDLh1VDNaUgsnS/k/g==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@firebase/component": "0.7.0",
         "@firebase/logger": "0.5.0",
@@ -647,7 +645,6 @@
       "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.5.8.tgz",
       "integrity": "sha512-4De6SUZ36zozl9kh5rZSxKWULpgty27rMzZ6x+xkoo7+NWyhWyFdsdvhFsWhTw/9GGj0wXIcbTjwHYCUIUuHyg==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@firebase/app": "0.14.8",
         "@firebase/component": "0.7.0",
@@ -663,8 +660,7 @@
       "version": "0.9.3",
       "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.9.3.tgz",
       "integrity": "sha512-kRVpIl4vVGJ4baogMDINbyrIOtOxqhkZQg4jTq3l8Lw6WSk0xfpEYzezFu+Kl4ve4fbPl79dvwRtaFqAC/ucCw==",
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/@firebase/auth-compat": {
       "version": "0.6.2",
@@ -1115,7 +1111,6 @@
       "integrity": "sha512-0AZUyYUfpMNcztR5l09izHwXkZpghLgCUaAGjtMwXnCg3bj4ml5VgiwqOMOxJ+Nw4qN/zJAaOQBcJ7KGkWStqQ==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       },
@@ -2196,7 +2191,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -6638,7 +6632,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -6649,7 +6642,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -6766,7 +6758,6 @@
       "integrity": "sha512-4z2nCSBfVIMnbuu8uinj+f0o4qOeggYJLbjpPHka3KH1om7e+H9yLKTYgksTaHcGco+NClhhY2vyO3HsMH1RGw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.55.0",
         "@typescript-eslint/types": "8.55.0",
@@ -7366,7 +7357,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -7965,7 +7955,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -9045,7 +9034,6 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.2.tgz",
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -9231,7 +9219,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -10604,7 +10591,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.2.tgz",
       "integrity": "sha512-gJnaDHXKDayjt8ue0n8Gs0A007yKXj4Xzb8+cNjZeYsSzzwKc0Lr+OZgYwVfB0pHfUs17EPoLvrOsEaJ9mj+Tg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -11677,8 +11663,7 @@
       "version": "1.9.4",
       "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
       "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
-      "license": "BSD-2-Clause",
-      "peer": true
+      "license": "BSD-2-Clause"
     },
     "node_modules/levn": {
       "version": "0.4.1",
@@ -13463,7 +13448,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -13889,7 +13873,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.0.tgz",
       "integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -13920,7 +13903,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.0.tgz",
       "integrity": "sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -13933,7 +13915,6 @@
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.71.1.tgz",
       "integrity": "sha512-9SUJKCGKo8HUSsCO+y0CtqkqI5nNuaDqTxyqPsZPqIwudpj4rCrAz/jZV+jn57bx5gtZKOh3neQu94DXMc+w5w==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -13998,7 +13979,6 @@
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
       "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -14135,8 +14115,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -15511,7 +15490,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -15769,7 +15747,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -16456,7 +16433,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/app/api/admin/fix-milestones/route.ts
+++ b/src/app/api/admin/fix-milestones/route.ts
@@ -165,19 +165,39 @@ export async function POST(req: NextRequest) {
 
           // Batch write correct milestones
           const now = admin.firestore.Timestamp.now();
-          // Find the date of the user's first workout as milestone date
-          const firstWorkoutDate = completed.length > 0
-            ? completed.reduce((earliest, w) => {
-                const d = w.date?.toDate?.() ?? new Date(w.date?._seconds ? w.date._seconds * 1000 : Date.now());
-                return d < earliest ? d : earliest;
-              }, new Date())
-            : new Date();
+
+          // Helper to parse admin SDK dates
+          const parseDate = (raw: any): Date => {
+            if (!raw) return new Date();
+            if (typeof raw.toDate === 'function') return raw.toDate();
+            if (typeof raw._seconds === 'number') return new Date(raw._seconds * 1000);
+            if (typeof raw.seconds === 'number') return new Date(raw.seconds * 1000);
+            const d = new Date(raw);
+            return isNaN(d.getTime()) ? new Date() : d;
+          };
+
+          // Find earliest workout date (overall and per-type) for milestone dates
+          const earliestByType: Record<string, Date> = {};
+          let earliestOverall = new Date();
+          for (const w of completed) {
+            const d = parseDate(w.date);
+            if (d.getTime() <= 0) continue;
+            if (d < earliestOverall) earliestOverall = d;
+            if (!earliestByType[w.type] || d < earliestByType[w.type]) {
+              earliestByType[w.type] = d;
+            }
+          }
 
           for (const ms of correctMilestones) {
             if (opCount >= 490) {
               batches.push(db.batch());
               opCount = 0;
             }
+            // For first_ever milestones, use the date of the first workout of that type
+            const milestoneDate = ms.category === 'first_ever' && earliestByType[ms.unit]
+              ? earliestByType[ms.unit]
+              : earliestOverall;
+
             const ref = db.collection('users').doc(username).collection('milestones').doc();
             batches[batches.length - 1].set(ref, {
               userId: username,
@@ -187,7 +207,7 @@ export async function POST(req: NextRequest) {
               value: ms.value,
               unit: ms.unit,
               icon: ms.icon,
-              date: admin.firestore.Timestamp.fromDate(firstWorkoutDate),
+              date: admin.firestore.Timestamp.fromDate(milestoneDate),
               createdAt: now,
             });
             opCount++;

--- a/src/components/achievements/DashboardAchievements.tsx
+++ b/src/components/achievements/DashboardAchievements.tsx
@@ -5,6 +5,7 @@ import { getPersonalRecords, getMilestones } from '@/lib/firebase/firestore';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Trophy, Star, ChevronRight, Flame, Medal, Award, X, Share2 } from 'lucide-react';
 import { format } from 'date-fns';
+import { safeToDate } from '@/lib/dateUtils';
 import Link from 'next/link';
 import type { PersonalRecord } from '@/types';
 import type { Milestone } from '@/types/achievements';
@@ -91,7 +92,7 @@ export function DashboardAchievements({ username, prefetchedPRs, prefetchedMiles
           <CardContent>
             <div className="space-y-2">
               {prs.map((pr) => {
-                const d = pr.date?.toDate?.() ?? new Date(pr.date as any);
+                const d = safeToDate({ date: pr.date });
                 return (
                   <div
                     key={pr.id}
@@ -140,7 +141,7 @@ export function DashboardAchievements({ username, prefetchedPRs, prefetchedMiles
           <CardContent>
             <div className="space-y-2">
               {milestones.map((ms) => {
-                const d = ms.date?.toDate?.() ?? new Date(ms.date as any);
+                const d = safeToDate({ date: ms.date });
                 const IconComp = MILESTONE_ICONS[ms.icon] || Star;
                 const colorClass = CATEGORY_COLORS[ms.category] || 'text-amber-500';
                 return (
@@ -184,7 +185,7 @@ export function DashboardAchievements({ username, prefetchedPRs, prefetchedMiles
                 unit: selectedMilestone.unit,
                 icon: selectedMilestone.icon,
               }}
-              date={selectedMilestone.date?.toDate?.() ?? new Date(selectedMilestone.date as any)}
+              date={safeToDate({ date: selectedMilestone.date })}
               userName={username}
             />
             <div className="mt-4 flex justify-center">

--- a/src/components/achievements/DashboardAchievements.tsx
+++ b/src/components/achievements/DashboardAchievements.tsx
@@ -1,16 +1,18 @@
 'use client';
 
 import { useEffect, useState, useRef } from 'react';
-import { getPersonalRecords, getMilestones } from '@/lib/firebase/firestore';
+import { getPersonalRecords, getMilestones, updateMilestoneDate } from '@/lib/firebase/firestore';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Trophy, Star, ChevronRight, Flame, Medal, Award, X, Share2 } from 'lucide-react';
 import { format } from 'date-fns';
 import { safeToDate } from '@/lib/dateUtils';
+import { Timestamp } from 'firebase/firestore';
 import Link from 'next/link';
 import type { PersonalRecord } from '@/types';
 import type { Milestone } from '@/types/achievements';
 import { MilestoneCard } from './MilestoneCard';
 import { ShareButtons } from '@/components/workouts/ShareWorkoutCard';
+import { useWorkoutStore } from '@/lib/stores/workoutStore';
 
 const MILESTONE_ICONS: Record<string, React.ComponentType<{ className?: string }>> = {
   star: Star, medal: Medal, award: Award, trophy: Trophy, flame: Flame,
@@ -63,6 +65,55 @@ export function DashboardAchievements({ username, prefetchedPRs, prefetchedMiles
     }
     load();
   }, [username, prefetchedPRs, prefetchedMilestones]);
+
+  // Self-heal milestone epoch-zero dates: if any milestone has a date at or before
+  // Unix epoch (Dec 31, 1969 / Jan 1, 1970 bug), look up the actual first workout
+  // of that type and patch the Firestore document.
+  useEffect(() => {
+    if (milestones.length === 0) return;
+
+    const EPOCH_THRESHOLD = 86400000; // 1 day in ms — anything before Jan 2, 1970 is suspect
+    const badMilestones = milestones.filter(ms => {
+      const d = safeToDate({ date: ms.date });
+      return d.getTime() < EPOCH_THRESHOLD;
+    });
+    if (badMilestones.length === 0) return;
+
+    (async () => {
+      try {
+        const allWorkouts = await useWorkoutStore.getState().getWorkouts(username, 'athlete');
+        const completed = allWorkouts.filter(w => w.completed);
+        let changed = false;
+
+        for (const ms of badMilestones) {
+          // For first_ever milestones, find the earliest workout of that type
+          // For other categories, find the earliest completed workout overall
+          const candidates = ms.category === 'first_ever'
+            ? completed.filter(w => w.type === ms.unit)
+            : completed;
+
+          const dates = candidates
+            .map(w => safeToDate(w))
+            .filter(d => d.getTime() > EPOCH_THRESHOLD)
+            .sort((a, b) => a.getTime() - b.getTime());
+
+          if (dates.length > 0) {
+            await updateMilestoneDate(username, ms.id, dates[0]);
+            // Update local state so the UI shows the correct date immediately
+            ms.date = Timestamp.fromDate(dates[0]);
+            changed = true;
+          }
+        }
+
+        if (changed) {
+          setMilestones(prev => [...prev]); // trigger re-render
+          console.log(`[milestones] self-healed ${badMilestones.length} epoch-zero dates`);
+        }
+      } catch (err) {
+        console.error('[milestones] self-heal failed (non-fatal):', err);
+      }
+    })();
+  }, [milestones.length, username]); // only run when milestones first load
 
   if (loading) return null;
 

--- a/src/hooks/useStravaAutoSync.ts
+++ b/src/hooks/useStravaAutoSync.ts
@@ -3,6 +3,7 @@
 import { useEffect, useRef, useState, useCallback } from 'react';
 import { User, Workout } from '@/types';
 import { toast } from 'sonner';
+import { safeToDate } from '@/lib/dateUtils';
 
 const SYNC_COOLDOWN_KEY = 'coachtrack_last_strava_sync';
 export const SYNC_COOLDOWN_UNTIL_KEY = 'coachtrack_strava_cooldown_until';
@@ -40,8 +41,8 @@ async function runPostSyncAchievements(username: string, user: User) {
     const recentStrava = allWorkouts
       .filter((w: Workout) => w.completed && (w.source === 'strava' || w.completedBy === 'strava'))
       .sort((a: Workout, b: Workout) => {
-        const da = (a.completedAt as any)?.toDate?.() ?? new Date(a.completedAt as any);
-        const db = (b.completedAt as any)?.toDate?.() ?? new Date(b.completedAt as any);
+        const da = safeToDate({ date: a.completedAt });
+        const db = safeToDate({ date: b.completedAt });
         return db.getTime() - da.getTime();
       })
       .slice(0, 1);

--- a/src/lib/achievements.ts
+++ b/src/lib/achievements.ts
@@ -8,7 +8,20 @@ import { isSameDay, subDays } from 'date-fns';
 
 function toDate(w: Workout): Date {
   try {
-    const d = (w.date as any)?.toDate?.() ?? new Date(w.date as any);
+    const raw = w.date as any;
+    if (!raw) return new Date(0);
+
+    // Firestore Timestamp with .toDate() method
+    if (typeof raw === 'object' && typeof raw.toDate === 'function') {
+      return raw.toDate();
+    }
+
+    // Serialized Firestore Timestamp (lost .toDate() after JSON round-trip via localStorage)
+    if (typeof raw === 'object' && typeof raw.seconds === 'number') {
+      return new Date(raw.seconds * 1000 + (raw.nanoseconds ?? 0) / 1e6);
+    }
+
+    const d = new Date(raw);
     return isNaN(d.getTime()) ? new Date(0) : d;
   } catch { return new Date(0); }
 }
@@ -115,6 +128,20 @@ export async function checkAchievements(
     const detected = detectNewMilestones(stats, existingMilestones);
 
     for (const milestone of detected) {
+      // For first_ever milestones, use the date of the earliest completed workout
+      // of that type (not the triggering workout date)
+      let milestoneDate = workoutDate;
+      if (milestone.category === 'first_ever') {
+        const earliest = completedWorkouts
+          .filter(w => w.type === milestone.unit) // unit holds the sport type for first_ever
+          .map(w => toDate(w))
+          .filter(d => d.getTime() > 0) // exclude epoch-zero dates
+          .sort((a, b) => a.getTime() - b.getTime());
+        if (earliest.length > 0) {
+          milestoneDate = earliest[0];
+        }
+      }
+
       const id = await addMilestone(username, {
         userId,
         category: milestone.category,
@@ -123,7 +150,7 @@ export async function checkAchievements(
         value: milestone.value,
         unit: milestone.unit,
         icon: milestone.icon,
-        date: workoutDate,
+        date: milestoneDate,
         workoutId: workout.id,
       });
       if (id) {

--- a/src/lib/dateUtils.ts
+++ b/src/lib/dateUtils.ts
@@ -3,10 +3,20 @@ import { format } from 'date-fns';
 export function safeToDate(w: { date?: unknown }): Date {
   try {
     const raw = w.date;
-    const d =
-      raw && typeof raw === 'object' && 'toDate' in raw && typeof (raw as { toDate: () => Date }).toDate === 'function'
-        ? (raw as { toDate: () => Date }).toDate()
-        : new Date(raw as string | number);
+    if (!raw) return new Date(0);
+
+    // Firestore Timestamp with .toDate() method
+    if (typeof raw === 'object' && 'toDate' in raw && typeof (raw as { toDate: () => Date }).toDate === 'function') {
+      return (raw as { toDate: () => Date }).toDate();
+    }
+
+    // Serialized Firestore Timestamp (lost .toDate() after JSON round-trip via localStorage)
+    if (typeof raw === 'object' && 'seconds' in raw && typeof (raw as { seconds: number }).seconds === 'number') {
+      const ts = raw as { seconds: number; nanoseconds?: number };
+      return new Date(ts.seconds * 1000 + (ts.nanoseconds ?? 0) / 1e6);
+    }
+
+    const d = new Date(raw as string | number);
     return isNaN(d.getTime()) ? new Date(0) : d;
   } catch {
     return new Date(0);

--- a/src/lib/firebase/firestore.ts
+++ b/src/lib/firebase/firestore.ts
@@ -741,6 +741,16 @@ export async function getMilestones(username: string): Promise<Milestone[]> {
   }
 }
 
+/** Update the date on a milestone document (used for self-healing epoch-zero dates) */
+export async function updateMilestoneDate(
+  username: string,
+  milestoneId: string,
+  date: Date,
+): Promise<void> {
+  const ref = doc(getDbInstance(), 'users', username, 'milestones', milestoneId);
+  await updateDoc(ref, { date: Timestamp.fromDate(date) });
+}
+
 export async function addMilestone(
   username: string,
   data: {


### PR DESCRIPTION
## Summary

- **Root cause:** Firestore Timestamps cached to localStorage via `JSON.stringify()` lose their `.toDate()` method. When the workout store returns these serialized objects, date parsing falls through to `new Date({seconds:...})` → NaN → fallback `new Date(0)` = Dec 31, 1969.
- Fix `safeToDate` (dateUtils) and `toDate` (achievements) to handle serialized Timestamps (plain objects with `.seconds` property)
- Use `safeToDate` in DashboardAchievements and useStravaAutoSync instead of inline `.toDate()` fallback chains
- For first_ever milestones, use the date of the **earliest completed workout of that type** instead of the triggering workout's date
- Add self-healing: when DashboardAchievements loads milestones with epoch-zero dates, it automatically patches Firestore with the correct date from the workout cache — fixes existing bad data on next dashboard visit
- Fix admin fix-milestones endpoint to use per-type dates for first_ever milestones

## Test plan

- [ ] Open dashboard — "First Run" and "First Swim" should auto-heal from "Dec 31, 1969" to actual first workout dates
- [ ] Check browser console for `[milestones] self-healed 2 epoch-zero dates` log
- [ ] Refresh dashboard — dates should persist correctly (no more epoch zero)
- [ ] Disconnect/reconnect Strava and verify new milestones get correct dates

https://claude.ai/code/session_017vbtenTiBDfaBS4phM8iiA