### PR TITLE
Remove undefined values from workout summary objects

### DIFF
--- a/src/lib/training/summary.ts
+++ b/src/lib/training/summary.ts
@@ -66,7 +66,7 @@ export function computeWorkoutSummary(
     ? classifyAdherence(workout, metrics, planMeta)
     : 'unplanned';
 
-  return {
+  return stripUndefined({
     generatedAt: Date.now(),
     forVersion: workout.summaryVersion ?? 1,
     sport: workout.type,
@@ -83,7 +83,7 @@ export function computeWorkoutSummary(
     hasGps: signal.hasGps,
     hasHr: signal.hasHr,
     hasPower: signal.hasPower,
-  };
+  });
 }
 
 /**
@@ -361,4 +361,11 @@ function toMeters(distance: number, unit?: string): number {
 function toIsoDate(workout: Workout): string {
   const d = safeToDate(workout);
   return d.toISOString().slice(0, 10);
+}
+
+/** Remove undefined values so Firestore never sees them in nested summary objects. */
+function stripUndefined<T extends object>(obj: T): T {
+  return Object.fromEntries(
+    Object.entries(obj).filter(([, v]) => v !== undefined),
+  ) as T;
 }


### PR DESCRIPTION
## Summary
Modified the `computeWorkoutSummary` function to filter out undefined values before returning the summary object. This prevents undefined properties from being persisted to Firestore in nested summary objects.

## Changes
- Added a new `stripUndefined` utility function that removes properties with undefined values from objects
- Updated `computeWorkoutSummary` to wrap its return object with `stripUndefined()` before returning
- This ensures that optional properties that are undefined are not included in the final summary object sent to Firestore

## Implementation Details
The `stripUndefined` function uses `Object.entries()` and `Object.fromEntries()` to filter out any key-value pairs where the value is `undefined`, maintaining type safety with a generic type parameter. This is a non-breaking change that only affects the shape of objects persisted to the database by removing empty/undefined fields.

https://claude.ai/code/session_01HXLieSXUaYT5pZAVdkuy8T