### PR TITLE
feat(notifications): enrich push notification bodies with workout details and coach fan-out

### DIFF
--- a/docs/brainstorms/2026-04-20-push-notification-summary-requirements.md
+++ b/docs/brainstorms/2026-04-20-push-notification-summary-requirements.md
@@ -1,0 +1,47 @@
+---
+date: 2026-04-20
+topic: push-notification-summary
+---
+
+# Push Notification — Richer Workout Summaries
+
+## Problem Frame
+Push notifications for Strava webhook events (activity created/updated/deleted) currently show a generic body: "A new workout was synced from Strava". Users can't tell what was synced without opening the app. Issue #78 requests that workout-specific details — name, sport type, distance, and duration — appear directly in the notification body.
+
+Manual sync, weekly wrap, and coach notifications are already descriptive and need no change.
+
+## Requirements
+- R1. When a Strava webhook triggers a **create** or **update** notification, the body must include the workout name, a sport emoji, distance (in km to 1 decimal), and duration — e.g. `"🏃 Morning Run • 5.2 km • 32 min"`.
+- R2. Fields that are zero or missing (e.g. strength workouts have no distance) must be omitted gracefully — the notification must never show "0 km" or "0 min".
+- R3. When a **delete** notification fires and the workout name is known, the body must name the removed workout — e.g. `"Morning Run was removed"`.
+- R4. The fallback body when no workout details are available must remain `"A new workout was synced from Strava"` to avoid blank notifications.
+
+## Success Criteria
+- A post-sync push notification on a real device shows workout name + stats instead of the generic fallback string.
+- Strength-only workouts (no distance) show name + duration only, no distance segment.
+- `npm run build` passes with no TypeScript errors.
+
+## Scope Boundaries
+- Manual sync notification (`/api/strava/sync`) — already descriptive, out of scope.
+- Weekly wrap push notification — already includes workout count, out of scope.
+- Coach completion notification — already descriptive, out of scope.
+- Notification icon, badge, sound, or action buttons — out of scope.
+
+## Key Decisions
+- **Carry details in the return value of `processActivity`** rather than doing an extra Firestore read in the notification sender. All required data (`activity.name`, `activity.distance`, `activity.moving_time`, `workoutType`) is already in scope at the success return sites — no extra reads needed.
+- **Sport emoji via a local constant map** (`run→🏃`, `bike→🚴`, `swim→🏊`, `walk→🚶`, `strength→💪`, `other→⚡`). Keeps the webhook file self-contained without importing shared UI config.
+
+## Dependencies / Assumptions
+- `processActivity` (and `processActivityUpdate`, which delegates to it) has `activity` in scope at all success return sites — the data is available without extra fetches.
+- The return type interface is local to `src/app/api/webhooks/strava/route.ts` — changing it does not affect any other module.
+
+## Outstanding Questions
+
+### Resolve Before Planning
+*(none — implementation is unblocked)*
+
+### Deferred to Planning
+*(none)*
+
+## Next Steps
+→ Run `/ce:plan` for structured implementation planning.

--- a/docs/plans/2026-04-20-001-feat-push-notifications-enrichment-coach-fanout-plan.md
+++ b/docs/plans/2026-04-20-001-feat-push-notifications-enrichment-coach-fanout-plan.md
@@ -1,0 +1,256 @@
+---
+title: "feat: Push notification enrichment, account isolation, and coach fan-out"
+type: feat
+status: active
+date: 2026-04-20
+origin: docs/brainstorms/2026-04-20-push-notification-summary-requirements.md
+---
+
+# feat: Push Notification Enrichment, Account Isolation & Coach Fan-Out
+
+## Overview
+
+Three layered improvements to the push notification system, addressing issue #78 and extending it to a coach-aware architecture:
+
+1. **Enrich notification bodies** — Strava webhook notifications currently say "A new workout was synced from Strava". Show workout name, sport emoji, distance, and duration instead.
+2. **Verify account isolation** — Confirm no cross-athlete leakage exists; document the guarantee explicitly.
+3. **Coach fan-out** — When any linked athlete's Strava activity is processed, the coach also receives a push notification that includes the athlete's name.
+
+## Problem Statement
+
+- **Notification bodies are generic** (issue #78): athletes can't tell what was synced without opening the app.
+- **Coaches are blind to real-time athlete activity**: they only receive a notification when an athlete manually marks a coach-assigned workout as completed. Strava sync events, which represent actual training, are invisible to coaches.
+- **No explicit account-isolation guarantee**: while the underlying `sendPushNotification` is correctly scoped, the contract is undocumented and should be verified as coach fan-out adds cross-account sends.
+
+## Proposed Solution
+
+### Part 1 — Enrich notification bodies (origin: docs/brainstorms/2026-04-20-push-notification-summary-requirements.md)
+
+Extend `processActivity`'s return type to carry `workoutName`, `workoutType`, `distanceMeters`, and `durationSeconds`. Add a `formatWorkoutBody()` helper and use it in the webhook notification sender.
+
+**Decision carried from origin:** Carry details in the return value — NOT via an extra Firestore read — because the data is already in scope at every success return site.
+
+### Part 2 — Account isolation
+
+No code changes needed. The current system is secure:
+- `sendPushNotification(username, payload)` reads only `users/{username}.pushSubscriptions` — no cross-user reads.
+- Webhook finds the target athlete via `where('stravaId', '==', ownerId)` — maps one Strava account to one app user.
+- Push subscription scoping (issue #74) removes prior-user subscriptions on device switch.
+
+The only new cross-account send introduced by this plan is coach←athlete, which is an explicit opt-in relationship via `coachUsername`.
+
+### Part 3 — Coach fan-out
+
+When the Strava webhook successfully processes an activity, check if the athlete has a `coachUsername`. If so, send a second notification to the coach with the athlete's name prepended to the body.
+
+**Zero extra Firestore reads** in the webhook path — `userDoc.data()` (line 386, webhook route) already contains `coachUsername`.
+
+Manual sync adds **one** Firestore read to fetch `coachUsername` if not already in scope.
+
+## Technical Approach
+
+### Files to Modify
+
+| File | Change |
+|------|--------|
+| `src/app/api/webhooks/strava/route.ts` | Extend return type, add `formatWorkoutBody()`, add coach fan-out in `.then()` |
+| `src/app/api/strava/sync/route.ts` | Add coach fan-out after sync notification (one Firestore read) |
+
+No other notification paths (weekly wrap, coach/route.ts, PushNotificationManager) require changes.
+
+### Webhook Route Changes (`src/app/api/webhooks/strava/route.ts`)
+
+#### 1. Extend the return type (line 369)
+
+```typescript
+// Before
+Promise<{ success: boolean; message: string }>
+
+// After
+Promise<{
+  success: boolean;
+  message: string;
+  workoutName?: string;
+  workoutType?: string;
+  distanceMeters?: number;
+  durationSeconds?: number;
+  coachUsername?: string;   // ← new: fan-out target
+  athleteDisplayName?: string; // ← new: for coach notification body
+}>
+```
+
+#### 2. Add `formatWorkoutBody()` helper (near top of file, after `mapStravaType`)
+
+```typescript
+const SPORT_EMOJI: Record<string, string> = {
+  run: '🏃', bike: '🚴', swim: '🏊', walk: '🚶', strength: '💪', other: '⚡',
+};
+
+function formatWorkoutBody(
+  name?: string,
+  type?: string,
+  distanceMeters?: number,
+  durationSeconds?: number,
+): string {
+  const parts: string[] = [];
+  if (name) parts.push(`${SPORT_EMOJI[type ?? ''] ?? '🏅'} ${name}`);
+  if (distanceMeters && distanceMeters > 0)
+    parts.push(`${(distanceMeters / 1000).toFixed(1)} km`);
+  if (durationSeconds && durationSeconds > 0) {
+    const h = Math.floor(durationSeconds / 3600);
+    const m = Math.floor((durationSeconds % 3600) / 60);
+    parts.push(h > 0 ? `${h}h ${m}min` : `${m} min`);
+  }
+  return parts.join(' • ') || 'A new workout was synced from Strava';
+}
+```
+
+#### 3. Update success return sites in `processActivity` to carry details
+
+Three success returns have `activity` and `workoutType` in scope:
+
+- **Line 463** (proximity duplicate — no notification, skip)
+- **Line 656** (reconciled existing workout):
+  ```typescript
+  return {
+    success: true,
+    message: `Reconciled Strava activity ...`,
+    workoutName: activity.name,
+    workoutType,
+    distanceMeters: activity.distance,
+    durationSeconds: activity.moving_time,
+    coachUsername: userData.coachUsername ?? undefined,
+    athleteDisplayName: userData.displayName ?? username,
+  };
+  ```
+- **Line 668** (newly created workout): same additions
+- Matched-planned-workout path (~line 535): same additions
+
+#### 4. Use helper + coach fan-out in the `.then()` callback (lines 833–851)
+
+```typescript
+.then(async (result) => {
+  if (result.success) {
+    const userSnap = await adminDb.collection('users')
+      .where('stravaId', '==', String(ownerId)).limit(1).get();
+    if (!userSnap.empty) {
+      const username = userSnap.docs[0].id;
+      const titleByAspect: Record<string, string> = {
+        create: '🏃 New Strava Workout',
+        update: '🔄 Strava Workout Updated',
+        delete: '🗑️ Strava Workout Removed',
+      };
+
+      const body = aspect_type === 'delete'
+        ? (result.workoutName ? `${result.workoutName} was removed` : 'A workout was removed from Strava')
+        : formatWorkoutBody(result.workoutName, result.workoutType, result.distanceMeters, result.durationSeconds);
+
+      // Notify the athlete
+      await sendPushNotification(username, {
+        title: titleByAspect[aspect_type] || '🔄 Strava Sync',
+        body,
+        url: '/workouts',
+      }).catch(() => {});
+
+      // Fan-out to coach if linked
+      if (result.coachUsername) {
+        const athleteName = result.athleteDisplayName || username;
+        const coachBody = aspect_type === 'delete'
+          ? `${athleteName}: ${result.workoutName ?? 'a workout'} was removed`
+          : `${athleteName}: ${body}`;
+        await sendPushNotification(result.coachUsername, {
+          title: titleByAspect[aspect_type] || '🔄 Athlete Strava Sync',
+          body: coachBody,
+          url: `/workouts`,
+        }).catch(() => {});
+      }
+    }
+  }
+})
+```
+
+> **Note on existing userSnap query**: The `.then()` callback already queries for `username` via `where('stravaId', ...)`. The `coachUsername` is now returned from `processActivity` (no extra read). Net cost: 0 additional Firestore reads vs current.
+
+### Manual Sync Route Changes (`src/app/api/strava/sync/route.ts`)
+
+After the existing notification block at line 1239–1245, add coach fan-out:
+
+```typescript
+if (newWorkoutsCount > 0 || mergedWorkoutsCount > 0) {
+  sendPushNotification(userId, {
+    title: '🏃 Strava Sync Complete',
+    body: message,
+    url: '/workouts',
+  }).catch(() => {});
+
+  // Fan-out to coach (1 Firestore read)
+  adminDb.collection('users').doc(userId).get().then((userDoc) => {
+    const coachUsername = userDoc.data()?.coachUsername;
+    const athleteName = userDoc.data()?.displayName || userId;
+    if (coachUsername) {
+      sendPushNotification(coachUsername, {
+        title: '🏃 Athlete Strava Sync Complete',
+        body: `${athleteName}: ${message}`,
+        url: '/workouts',
+      }).catch(() => {});
+    }
+  }).catch(() => {});
+}
+```
+
+## System-Wide Impact
+
+### Interaction Graph
+- `POST /api/webhooks/strava` → `processActivity()` → `.then()` sends to athlete → sends to `result.coachUsername` (if set). Both `sendPushNotification` calls are non-blocking (`.catch(() => {})`).
+- `POST /api/strava/sync` → existing notification → one Firestore read → conditional coach notification. Coach send is fire-and-forget.
+
+### Error Propagation
+Both coach notifications are wrapped in `.catch(() => {})` — coach notification failures never surface to the response or the athlete notification. Coach fan-out is best-effort.
+
+### State Lifecycle Risks
+None. Notifications are fire-and-forget with no state mutations.
+
+### API Surface Parity
+- `src/app/api/notifications/coach/route.ts` (existing coach completion notification) does NOT need changes — it already includes athlete name in the body.
+
+## Acceptance Criteria
+
+- [ ] **R1** (origin): Strava webhook create/update notifications show sport emoji, name, distance, duration — e.g. `"🏃 Morning Run • 5.2 km • 32 min"`.
+- [ ] **R2** (origin): Zero-value fields (distance=0 or duration=0) are omitted from the body.
+- [ ] **R3** (origin): Delete notification body includes workout name when available.
+- [ ] **R4** (origin): Fallback body `"A new workout was synced from Strava"` used when details unavailable.
+- [ ] **R5**: When athlete has a `coachUsername`, the coach receives a separate push notification for every Strava webhook create/update/delete event.
+- [ ] **R6**: Coach notification body prepends the athlete's display name: `"John: 🏃 Morning Run • 5.2 km • 32 min"`.
+- [ ] **R7**: Manual Strava sync also fan-outs to the coach with athlete name in body.
+- [ ] **R8**: Athletes with no `coachUsername` receive no coach notification (no regression).
+- [ ] **R9**: `npm run build` passes with no TypeScript errors.
+
+## Success Metrics
+- Push notification bodies on a real device show workout details instead of the generic string.
+- Coaches receive push notifications for their athletes' Strava activity without receiving other coaches' athletes' notifications.
+
+## Dependencies & Risks
+
+| Item | Notes |
+|------|-------|
+| `coachUsername` field on user doc | Must be set on athlete docs for fan-out to work. If unset, fan-out is silently skipped — correct behavior. |
+| Firestore read budget | Webhook path: 0 extra reads. Manual sync: 1 extra read per sync with activity changes. Low risk. |
+| Coach push subscriptions | Coach must have subscribed to push notifications (PWA installed + permission granted) to receive fan-out. If no subscriptions, `sendPushNotification` silently succeeds with no sends. |
+| Duplicate notifications in `.then()` | The `.then()` callback currently re-queries `userSnap` for `username`. The `coachUsername` is now carried from `processActivity` result — we avoid a second user-doc read. |
+
+## Sources & References
+
+### Origin Document
+- **[docs/brainstorms/2026-04-20-push-notification-summary-requirements.md](docs/brainstorms/2026-04-20-push-notification-summary-requirements.md)** — Key decisions carried forward:
+  - Carry workout details in return value (not extra Firestore reads)
+  - Sport emoji local constant map
+  - `formatWorkoutBody()` with graceful zero-field omission
+
+### Internal References
+- `src/lib/push.ts` — `sendPushNotification(username, payload)` — core send function
+- `src/app/api/webhooks/strava/route.ts:366-675` — `processActivity()` return sites
+- `src/app/api/webhooks/strava/route.ts:833-854` — notification `.then()` callback
+- `src/app/api/strava/sync/route.ts:1239-1245` — manual sync notification block
+- `src/app/api/mcp/route.ts:223-235` — `getLinkedAthletes` (established coach-athlete query pattern)
+- `src/app/api/notifications/coach/route.ts:84-88` — existing coach completion notification (reference for body format)
+- `src/types/index.ts:19` — `coachUsername?: string` field on User

--- a/src/app/api/strava/sync/route.ts
+++ b/src/app/api/strava/sync/route.ts
@@ -1241,7 +1241,20 @@ async function handleSync(request: NextRequest, opts: SyncOptions) {
         title: '🏃 Strava Sync Complete',
         body: message,
         url: '/workouts',
-      }).catch(() => {}); // non-fatal, fire and forget
+      }).catch(() => {});
+
+      // Fan-out to coach if athlete is linked to one (1 Firestore read)
+      adminDb.collection('users').doc(userId).get().then((userDoc) => {
+        const coachUsername = userDoc.data()?.coachUsername as string | undefined;
+        const athleteName = (userDoc.data()?.displayName as string | undefined) || userId;
+        if (coachUsername) {
+          sendPushNotification(coachUsername, {
+            title: '🏃 Athlete Strava Sync Complete',
+            body: `${athleteName}: ${message}`,
+            url: '/workouts',
+          }).catch(() => {});
+        }
+      }).catch(() => {});
     }
 
     // Redirect back to settings or return JSON based on request type

--- a/src/app/api/webhooks/strava/route.ts
+++ b/src/app/api/webhooks/strava/route.ts
@@ -35,6 +35,28 @@ function mapStravaType(stravaType: string): 'swim' | 'run' | 'walk' | 'bike' | '
   return typeMap[stravaType] || 'strength';
 }
 
+const SPORT_EMOJI: Record<string, string> = {
+  run: '🏃', bike: '🚴', swim: '🏊', walk: '🚶', strength: '💪', other: '⚡',
+};
+
+function formatWorkoutBody(
+  name?: string,
+  type?: string,
+  distanceMeters?: number,
+  durationSeconds?: number,
+): string {
+  const parts: string[] = [];
+  if (name) parts.push(`${SPORT_EMOJI[type ?? ''] ?? '🏅'} ${name}`);
+  if (distanceMeters && distanceMeters > 0)
+    parts.push(`${(distanceMeters / 1000).toFixed(1)} km`);
+  if (durationSeconds && durationSeconds > 0) {
+    const h = Math.floor(durationSeconds / 3600);
+    const m = Math.floor((durationSeconds % 3600) / 60);
+    parts.push(h > 0 ? `${h}h ${m}min` : `${m} min`);
+  }
+  return parts.join(' • ') || 'A new workout was synced from Strava';
+}
+
 // Verify Strava webhook signature
 function verifyWebhookSignature(body: string, signature: string): boolean {
   const verifyToken = process.env.STRAVA_WEBHOOK_VERIFY_TOKEN;
@@ -362,11 +384,22 @@ function applyDetailedFields(target: Record<string, any>, built: WorkoutFields, 
   if (activity.total_photo_count > 0) target.hasStravaPhotos = true;
 }
 
+type ActivityResult = {
+  success: boolean;
+  message: string;
+  workoutName?: string;
+  workoutType?: string;
+  distanceMeters?: number;
+  durationSeconds?: number;
+  coachUsername?: string;
+  athleteDisplayName?: string;
+};
+
 // Process a new Strava activity - CLEAN VERSION
 async function processActivity(
   stravaAthleteId: string,
   stravaActivityId: string
-): Promise<{ success: boolean; message: string }> {
+): Promise<ActivityResult> {
   try {
     console.log(`\n🏃 Processing Strava activity ${stravaActivityId} for athlete ${stravaAthleteId}`);
 
@@ -530,7 +563,13 @@ async function processActivity(
 
       return {
         success: true,
-        message: `Matched "${activity.name}" with planned workout "${matchedDoc.data().name}"`
+        message: `Matched "${activity.name}" with planned workout "${matchedDoc.data().name}"`,
+        workoutName: activity.name,
+        workoutType,
+        distanceMeters: activity.distance,
+        durationSeconds: activity.moving_time,
+        coachUsername: userData.coachUsername ?? undefined,
+        athleteDisplayName: userData.displayName ?? username,
       };
     }
 
@@ -579,7 +618,13 @@ async function processActivity(
           await batch.commit();
           return {
             success: true,
-            message: `Merged "${activity.name}" with imported workout "${iData.name}"`
+            message: `Merged "${activity.name}" with imported workout "${iData.name}"`,
+            workoutName: activity.name,
+            workoutType,
+            distanceMeters: activity.distance,
+            durationSeconds: activity.moving_time,
+            coachUsername: userData.coachUsername ?? undefined,
+            athleteDisplayName: userData.displayName ?? username,
           };
         }
       }
@@ -655,7 +700,13 @@ async function processActivity(
 
       return {
         success: true,
-        message: `Reconciled Strava activity into workout "${canonicalDoc.data().name || activity.name}"`
+        message: `Reconciled Strava activity into workout "${canonicalDoc.data().name || activity.name}"`,
+        workoutName: activity.name,
+        workoutType,
+        distanceMeters: activity.distance,
+        durationSeconds: activity.moving_time,
+        coachUsername: userData.coachUsername ?? undefined,
+        athleteDisplayName: userData.displayName ?? username,
       };
     }
 
@@ -667,7 +718,13 @@ async function processActivity(
 
     return {
       success: true,
-      message: `Created workout "${activity.name}" from Strava`
+      message: `Created workout "${activity.name}" from Strava`,
+      workoutName: activity.name,
+      workoutType,
+      distanceMeters: activity.distance,
+      durationSeconds: activity.moving_time,
+      coachUsername: userData.coachUsername ?? undefined,
+      athleteDisplayName: userData.displayName ?? username,
     };
   } catch (error: any) {
     console.error('❌ Error processing activity:', error);
@@ -678,7 +735,7 @@ async function processActivity(
 async function processActivityUpdate(
   stravaAthleteId: string,
   stravaActivityId: string
-): Promise<{ success: boolean; message: string }> {
+): Promise<ActivityResult> {
   console.log(`\n🔄 Processing Strava activity update ${stravaActivityId} for athlete ${stravaAthleteId}`);
   // Reuse the create-path reconciliation logic:
   // it updates existing docs, promotes planned when available, and removes redundant standalone copies.
@@ -688,7 +745,7 @@ async function processActivityUpdate(
 async function processActivityDelete(
   stravaAthleteId: string,
   stravaActivityId: string
-): Promise<{ success: boolean; message: string }> {
+): Promise<ActivityResult> {
   try {
     console.log(`\n🗑️ Processing Strava activity delete ${stravaActivityId} for athlete ${stravaAthleteId}`);
 
@@ -704,6 +761,7 @@ async function processActivityDelete(
 
     const userDoc = usersSnapshot.docs[0];
     const username = userDoc.id;
+    const userData = userDoc.data();
 
     const matches = await adminDb
       .collection('users').doc(username).collection('workouts')
@@ -757,9 +815,13 @@ async function processActivityDelete(
       unlinkedCount++;
     }
 
+    const deletedWorkoutName = matches.docs[0]?.data()?.name as string | undefined;
     return {
       success: true,
-      message: `Strava delete processed: removed ${deletedCount}, unlinked ${unlinkedCount}`
+      message: `Strava delete processed: removed ${deletedCount}, unlinked ${unlinkedCount}`,
+      workoutName: deletedWorkoutName,
+      coachUsername: userData.coachUsername ?? undefined,
+      athleteDisplayName: userData.displayName ?? username,
     };
   } catch (error: any) {
     console.error('❌ Error processing activity delete:', error);
@@ -844,11 +906,29 @@ export async function POST(request: NextRequest) {
                 delete: '🗑️ Strava Workout Removed',
               };
 
+              const body = aspect_type === 'delete'
+                ? (result.workoutName ? `${result.workoutName} was removed` : 'A workout was removed from Strava')
+                : formatWorkoutBody(result.workoutName, result.workoutType, result.distanceMeters, result.durationSeconds);
+
+              // Notify the athlete
               await sendPushNotification(username, {
                 title: titleByAspect[aspect_type] || '🔄 Strava Sync',
-                body: result.message || 'A new workout was synced from Strava',
+                body,
                 url: '/workouts',
-              }).catch(() => {}); // non-fatal
+              }).catch(() => {});
+
+              // Fan-out to coach if linked
+              if (result.coachUsername) {
+                const athleteName = result.athleteDisplayName || username;
+                const coachBody = aspect_type === 'delete'
+                  ? `${athleteName}: ${result.workoutName ?? 'a workout'} was removed`
+                  : `${athleteName}: ${body}`;
+                await sendPushNotification(result.coachUsername, {
+                  title: titleByAspect[aspect_type] || '🔄 Athlete Strava Sync',
+                  body: coachBody,
+                  url: '/workouts',
+                }).catch(() => {});
+              }
             }
           }
         })


### PR DESCRIPTION
## Summary
- **Richer notification bodies** (closes #78): Strava webhook notifications now show sport emoji, workout name, distance, and duration — e.g. `🏃 Morning Run • 5.2 km • 32 min` — instead of the generic fallback string. Zero-value fields (no distance for strength, etc.) are omitted gracefully.
- **Coach fan-out**: Coaches linked to an athlete via `coachUsername` now receive a push notification for every Strava sync event, with the athlete's display name prepended: `"John: 🏃 Morning Run • 5.2 km • 32 min"`. Manual sync also fans out to the coach.
- **Account isolation preserved**: Each notification is still scoped to its target username via `sendPushNotification(username, payload)`. The only new cross-account send is coach←athlete via an explicit opt-in relationship.

## Technical Details
- Added `ActivityResult` type and `formatWorkoutBody()` helper in the Strava webhook route.
- Extended `processActivity`, `processActivityUpdate`, and `processActivityDelete` return types to carry `workoutName`, `workoutType`, `distanceMeters`, `durationSeconds`, `coachUsername`, and `athleteDisplayName` — no extra Firestore reads (data already in scope at return sites).
- Manual sync coach fan-out uses one Firestore read, fire-and-forget, non-fatal.

## Testing
- TypeScript check passes (`npx tsc --noEmit` — no errors in modified files; pre-existing vitest config errors are unrelated).
- Manually verify: trigger a Strava activity sync and confirm the push notification body shows workout details. Test with an athlete who has `coachUsername` set to confirm coach receives a named notification.

## Post-Deploy Monitoring & Validation
- **Logs to watch**: Vercel function logs for `/api/webhooks/strava` — look for `✅ Webhook processing result:` entries to confirm `workoutName`/`coachUsername` fields are populated.
- **Expected healthy signal**: Notifications arrive on device with format `"🏃 Morning Run • 5.2 km • 32 min"`.
- **Failure signal**: Notifications still showing generic body → check that `activity.name`, `activity.distance`, `activity.moving_time` are present in Strava API response.
- **Coach fan-out failure signal**: Coach not receiving notifications → confirm athlete's `coachUsername` field is set in Firestore and coach has push subscriptions.
- **Rollback**: Both sends are `.catch(() => {})` — failures are silent and non-breaking. No state mutations, no rollback needed.
- **Validation window**: 24h post-deploy, confirmed on first real Strava sync.

---

[![Compound Engineering v2.47.0](https://img.shields.io/badge/Compound_Engineering-v2.47.0-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Sonnet 4.6 via [Claude Code](https://claude.com/claude-code)