### PR TITLE
feat(calendar): remove Late stigma + inline completion prompt

### DIFF
--- a/src/app/(dashboard)/calendar/page.tsx
+++ b/src/app/(dashboard)/calendar/page.tsx
@@ -25,7 +25,11 @@ import {
   subYears,
   startOfMonth,
   endOfMonth,
+  isToday,
+  isPast,
 } from 'date-fns';
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
 import { formatInTimezone, safeToDate } from '@/lib/dateUtils';
 import { parseLocalDate, getDayKey } from '@/lib/dayKey';
 import { computePlanWeekNumber } from '@/lib/training/weekNumber';
@@ -70,6 +74,9 @@ export default function CalendarPage() {
 
   // Report
   const [sendingReport, setSendingReport] = useState(false);
+
+  // Late completion prompt — shown when completing a past workout
+  const [latePromptWorkout, setLatePromptWorkout] = useState<Workout | null>(null);
 
   // ── Strava sync ──────────────────────────────────────────────────────
   const fromStrava = searchParams.get('strava') === 'connected';
@@ -209,22 +216,54 @@ export default function CalendarPage() {
     e.preventDefault();
     e.stopPropagation();
     const newCompleted = !workout.completed;
-    // Optimistic update — immediately reflect in UI
+
+    // When marking a past workout as complete, prompt the athlete first
+    if (newCompleted) {
+      const workoutDate = safeToDate(workout);
+      if (!isToday(workoutDate) && isPast(workoutDate)) {
+        setLatePromptWorkout(workout);
+        return;
+      }
+    }
+
+    await doCompleteWorkout(workout, newCompleted);
+  };
+
+  const doCompleteWorkout = async (workout: Workout, newCompleted: boolean, overrideDate?: Date) => {
     setWorkouts((prev) =>
-      prev.map((w) => w.id === workout.id ? { ...w, completed: newCompleted, completedBy: newCompleted ? 'manual' : undefined } as Workout : w)
+      prev.map((w) => {
+        if (w.id !== workout.id) return w;
+        const update: Partial<Workout> = { completed: newCompleted, completedBy: newCompleted ? 'manual' : undefined };
+        if (overrideDate) update.date = Timestamp.fromDate(overrideDate) as any;
+        return { ...w, ...update } as Workout;
+      })
     );
     toast.success(newCompleted ? 'Marked complete!' : 'Marked incomplete');
     try {
-      await completeWorkout(workout.ownerUsername, workout.id, newCompleted);
-      // Refresh cache in background for other pages
+      await completeWorkout(workout.ownerUsername, workout.id, newCompleted, undefined, undefined, overrideDate);
       invalidateWorkouts(user!.username, user!.role);
     } catch (err: any) {
-      // Revert on failure
       setWorkouts((prev) =>
         prev.map((w) => w.id === workout.id ? { ...w, completed: !newCompleted, completedBy: !newCompleted ? 'manual' : undefined } as Workout : w)
       );
       toast.error(err.message || 'Failed to update');
     }
+  };
+
+  const handleLatePromptKeep = async () => {
+    if (!latePromptWorkout) return;
+    const workout = latePromptWorkout;
+    setLatePromptWorkout(null);
+    track('late_completion_prompt_choice', { choice: 'keep', workout_id: workout.id });
+    await doCompleteWorkout(workout, true);
+  };
+
+  const handleLatePromptMoveToday = async () => {
+    if (!latePromptWorkout) return;
+    const workout = latePromptWorkout;
+    setLatePromptWorkout(null);
+    track('late_completion_prompt_choice', { choice: 'move_to_today', workout_id: workout.id });
+    await doCompleteWorkout(workout, true, new Date());
   };
 
   // ── Drag-to-reschedule (desktop, md+) ────────────────────────────────
@@ -660,6 +699,31 @@ export default function CalendarPage() {
           )}
         </div>
       </div>
+
+      {/* Late completion prompt */}
+      <Dialog open={!!latePromptWorkout} onOpenChange={(open) => { if (!open) setLatePromptWorkout(null); }}>
+        <DialogContent className="max-w-sm">
+          <DialogHeader>
+            <DialogTitle>Complete this workout?</DialogTitle>
+            <DialogDescription>
+              {latePromptWorkout && (
+                <>
+                  <strong>{latePromptWorkout.name}</strong> was scheduled for{' '}
+                  <strong>{format(safeToDate(latePromptWorkout), 'MMM d')}</strong>. How would you like to log it?
+                </>
+              )}
+            </DialogDescription>
+          </DialogHeader>
+          <div className="flex flex-col gap-2 pt-2">
+            <Button onClick={handleLatePromptKeep} variant="outline" className="w-full justify-start">
+              ✓ Keep on {latePromptWorkout ? format(safeToDate(latePromptWorkout), 'MMM d') : '…'}
+            </Button>
+            <Button onClick={handleLatePromptMoveToday} className="w-full justify-start">
+              📅 Move to today
+            </Button>
+          </div>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/src/app/(dashboard)/dashboard/page.tsx
+++ b/src/app/(dashboard)/dashboard/page.tsx
@@ -71,12 +71,11 @@ function getWorkoutStatus(workout: Workout) {
 
   const isStravaStandalone = workout.source === 'strava';
   const isMatchedByStrava = !isStravaStandalone && workout.completed && workout.completedBy === 'strava';
-  const isLate = workout.completedLate === true;
-  const isCompletedManual = workout.completed && !isStravaStandalone && !isMatchedByStrava && !isLate;
+  const isCompletedManual = workout.completed && !isStravaStandalone && !isMatchedByStrava;
   const isMissed = past && !workout.completed && !isStravaStandalone;
   const isFuture = !workout.completed && !past && !isStravaStandalone;
 
-  return { isStravaStandalone, isMatchedByStrava, isLate, isCompletedManual, isMissed, isFuture };
+  return { isStravaStandalone, isMatchedByStrava, isCompletedManual, isMissed, isFuture };
 }
 
 function getStatusStyles(status: ReturnType<typeof getWorkoutStatus>) {
@@ -90,12 +89,6 @@ function getStatusStyles(status: ReturnType<typeof getWorkoutStatus>) {
     return {
       border: 'border-orange-400 dark:border-orange-500/70',
       bg: 'bg-orange-100/80 dark:bg-orange-500/15',
-    };
-  }
-  if (status.isLate) {
-    return {
-      border: 'border-amber-400 dark:border-amber-500/70',
-      bg: 'bg-amber-100/80 dark:bg-amber-500/15',
     };
   }
   if (status.isMissed) {
@@ -114,7 +107,7 @@ function getStatusStyles(status: ReturnType<typeof getWorkoutStatus>) {
 }
 
 function getStatusIcon(status: ReturnType<typeof getWorkoutStatus>) {
-  if (status.isCompletedManual || status.isMatchedByStrava || status.isLate) {
+  if (status.isCompletedManual || status.isMatchedByStrava) {
     return <CheckCircle2 className="h-4 w-4 text-green-500 shrink-0" />;
   }
   if (status.isStravaStandalone) {

--- a/src/app/(dashboard)/workouts/page.tsx
+++ b/src/app/(dashboard)/workouts/page.tsx
@@ -97,7 +97,6 @@ function WorkoutRow({ workout, onDelete }: { workout: Workout; onDelete?: (worko
   const past = isPast(workoutDate) && !isToday(workoutDate);
   const isNote = workout.type === 'other' && workout.name === 'Note';
   const isMissed = past && !workout.completed && workout.source !== 'strava' && !isNote;
-  const isLate = workout.completedLate === true;
   const extraStats = getExtraStats(workout);
   const isPlanned = !workout.completed && (isFuture(workoutDate) || isToday(workoutDate));
 
@@ -119,11 +118,6 @@ function WorkoutRow({ workout, onDelete }: { workout: Workout; onDelete?: (worko
             'text-[13px] font-semibold truncate',
             isMissed && 'line-through text-muted-foreground',
           )}>{workout.name}</span>
-          {isLate && (
-            <Badge variant="secondary" className="text-[9px] shrink-0 bg-amber-500/10 text-amber-600 dark:text-amber-400 px-1.5 py-0">
-              Late
-            </Badge>
-          )}
         </div>
         <div className="flex items-center gap-1 text-[11px] text-muted-foreground mt-0.5">
           <span>{dateStr}</span>
@@ -175,7 +169,7 @@ function WorkoutRow({ workout, onDelete }: { workout: Workout; onDelete?: (worko
       {/* Completion status */}
       <div className="shrink-0">
         {workout.completed ? (
-          <CheckCircle2 className={cn('h-4.5 w-4.5', isLate ? 'text-amber-500' : 'text-green-500')} />
+          <CheckCircle2 className="h-4.5 w-4.5 text-green-500" />
         ) : isMissed ? (
           <AlertCircle className="h-4.5 w-4.5 text-red-500" />
         ) : (

--- a/src/components/calendar/CalendarWorkoutCard.tsx
+++ b/src/components/calendar/CalendarWorkoutCard.tsx
@@ -40,12 +40,11 @@ function getWorkoutStatus(workout: Workout) {
   // 6 states (evaluated in priority order)
   const isStravaStandalone = workout.source === 'strava';
   const isMatchedByStrava = !isStravaStandalone && workout.completed && workout.completedBy === 'strava';
-  const isLate = workout.completedLate === true;
-  const isCompletedManual = workout.completed && !isStravaStandalone && !isMatchedByStrava && !isLate;
+  const isCompletedManual = workout.completed && !isStravaStandalone && !isMatchedByStrava;
   const isMissed = past && !workout.completed && !isStravaStandalone && !isNote(workout);
   const isFuture = !workout.completed && !past && !isStravaStandalone;
 
-  return { isStravaStandalone, isMatchedByStrava, isLate, isCompletedManual, isMissed, isFuture, past, today };
+  return { isStravaStandalone, isMatchedByStrava, isCompletedManual, isMissed, isFuture, past, today };
 }
 
 // ── Status-driven border + fill styles ──────────────────────────────────
@@ -68,13 +67,6 @@ function getStatusStyles(status: ReturnType<typeof getWorkoutStatus>, noteMode: 
     return {
       border: 'border-orange-400 dark:border-orange-500/70',
       bg: 'bg-orange-100/80 dark:bg-orange-500/15',
-      opacity: '',
-    };
-  }
-  if (status.isLate) {
-    return {
-      border: 'border-amber-400 dark:border-amber-500/70',
-      bg: 'bg-amber-100/80 dark:bg-amber-500/15',
       opacity: '',
     };
   }
@@ -132,11 +124,9 @@ function MiniPill({ workout, onSelect }: { workout: Workout; onSelect?: (id: str
       ? 'Matched'
       : status.isStravaStandalone
         ? 'Strava'
-        : status.isLate
-          ? 'Late'
-          : status.isMissed
-            ? 'Missed'
-            : null;
+        : status.isMissed
+          ? 'Missed'
+          : null;
 
   const statusLabelColor = status.isCompletedManual
     ? 'text-green-600 dark:text-green-400'
@@ -144,11 +134,9 @@ function MiniPill({ workout, onSelect }: { workout: Workout; onSelect?: (id: str
       ? 'text-green-600 dark:text-green-400'
       : status.isStravaStandalone
         ? 'text-orange-600 dark:text-orange-400'
-        : status.isLate
-          ? 'text-amber-600 dark:text-amber-400'
-          : status.isMissed
-            ? 'text-red-600 dark:text-red-400'
-            : '';
+        : status.isMissed
+          ? 'text-red-600 dark:text-red-400'
+          : '';
 
   return (
     <button
@@ -183,7 +171,7 @@ function MiniPill({ workout, onSelect }: { workout: Workout; onSelect?: (id: str
         </span>
 
         {/* Status icons */}
-        {!noteMode && (status.isCompletedManual || status.isLate || status.isMatchedByStrava) && (
+        {!noteMode && (status.isCompletedManual || status.isMatchedByStrava) && (
           <CheckCircle2 className="h-3 w-3 text-green-500 shrink-0" />
         )}
         {(status.isStravaStandalone || status.isMatchedByStrava) && (
@@ -283,11 +271,6 @@ function CompactCard({
             {status.isCompletedManual && (
               <span className="shrink-0 px-2 py-0.5 rounded-full text-[10px] font-semibold bg-green-500/10 text-green-600 dark:text-green-400 border border-green-500/20">
                 Done
-              </span>
-            )}
-            {status.isLate && (
-              <span className="shrink-0 px-2 py-0.5 rounded-full text-[10px] font-semibold bg-amber-500/10 text-amber-600 dark:text-amber-400 border border-amber-500/20">
-                Late
               </span>
             )}
             {status.isMissed && (

--- a/src/components/calendar/WorkoutDetailPanel.tsx
+++ b/src/components/calendar/WorkoutDetailPanel.tsx
@@ -189,14 +189,9 @@ export function WorkoutDetailPanel({
 
         {/* Status */}
         <div className="flex items-center gap-2 text-sm">
-          {workout.completed && !workout.completedLate && (
+          {workout.completed && (
             <span className="flex items-center gap-1.5 text-green-600 font-semibold">
               <CheckCircle2 className="h-4 w-4" /> Completed
-            </span>
-          )}
-          {workout.completedLate && (
-            <span className="flex items-center gap-1.5 text-amber-600 font-semibold">
-              <CheckCircle2 className="h-4 w-4" /> Completed Late
             </span>
           )}
           {isMissed && (

--- a/src/components/dashboard/CoachDashboard.tsx
+++ b/src/components/dashboard/CoachDashboard.tsx
@@ -236,7 +236,7 @@ export function CoachDashboard({ username, timezone, prefetchedWorkouts }: Coach
                     className="flex items-center justify-between p-2 rounded-lg hover:bg-muted/50 transition-colors"
                   >
                     <div className="flex items-center gap-3 min-w-0">
-                      <CheckCircle2 className={cn('h-4 w-4 shrink-0', w.completedLate ? 'text-orange-500' : 'text-green-500')} />
+                      <CheckCircle2 className="h-4 w-4 shrink-0 text-green-500" />
                       <div className="min-w-0">
                         <p className="text-sm font-medium truncate">{w.name}</p>
                         <p className="text-xs text-muted-foreground">

--- a/src/components/workouts/WorkoutCard.tsx
+++ b/src/components/workouts/WorkoutCard.tsx
@@ -51,7 +51,6 @@ export function WorkoutCard({ workout, onEdit, onDelete, onToggleComplete, onVie
   const isPastWorkout = safeToDate(workout) < new Date();
   const isUpcoming = !isPastWorkout && !workout.completed;
   const isMissed = isPastWorkout && !workout.completed;
-  const isCompletedLate = workout.completed && workout.completedLate;
   const tags = (workout as any).tags as WorkoutTag[] | undefined;
   const plannedSummary = getWorkoutSummary(workout);
   const hasRoute = !!(workout.routeData?.polyline);
@@ -114,8 +113,7 @@ export function WorkoutCard({ workout, onEdit, onDelete, onToggleComplete, onVie
   })();
 
   const getCardStyle = () => {
-    if (workout.completed && !isCompletedLate) return 'border-l-4 border-l-green-500 bg-green-500/5';
-    if (isCompletedLate) return 'border-l-4 border-l-orange-500 bg-orange-500/5';
+    if (workout.completed) return 'border-l-4 border-l-green-500 bg-green-500/5';
     if (isUpcoming) return 'border-l-4 border-l-blue-500 bg-blue-500/5';
     if (isMissed) return 'border-l-4 border-l-red-500 bg-red-500/5';
     return '';
@@ -142,7 +140,7 @@ export function WorkoutCard({ workout, onEdit, onDelete, onToggleComplete, onVie
       >
         {workout.completed && (
           <div className="absolute top-4 right-4">
-            <CheckCircle2 className={cn('h-5 w-5', isCompletedLate ? 'text-orange-500' : 'text-green-500')} />
+            <CheckCircle2 className="h-5 w-5 text-green-500" />
           </div>
         )}
 
@@ -188,8 +186,7 @@ export function WorkoutCard({ workout, onEdit, onDelete, onToggleComplete, onVie
           )}
 
           <div className="flex flex-wrap gap-1.5 mb-3">
-            {workout.completed && !isCompletedLate && <Badge className="bg-green-500 hover:bg-green-600 text-xs"><CheckCircle2 className="h-3 w-3 mr-1" />Done</Badge>}
-            {isCompletedLate && <Badge className="bg-orange-500 hover:bg-orange-600 text-xs"><CheckCircle2 className="h-3 w-3 mr-1" />Late</Badge>}
+            {workout.completed && <Badge className="bg-green-500 hover:bg-green-600 text-xs"><CheckCircle2 className="h-3 w-3 mr-1" />Done</Badge>}
             {isUpcoming && <Badge variant="outline" className="border-blue-500/50 text-blue-600 dark:text-blue-400 text-xs"><Clock className="h-3 w-3 mr-1" />Upcoming</Badge>}
             {isMissed && <Badge variant="destructive" className="text-xs">Missed</Badge>}
             {workout.completedBy === 'strava' && <Badge variant="outline" className="border-orange-500/50 text-orange-600 dark:text-orange-400 text-xs"><Activity className="h-3 w-3 mr-1" />Strava</Badge>}

--- a/src/lib/firebase/firestore.ts
+++ b/src/lib/firebase/firestore.ts
@@ -347,18 +347,20 @@ export async function toggleWorkoutCompletion(ownerUsername: string, id: string,
   }
 }
 
-// Enhanced completion with notes and rating
+// Enhanced completion with notes, rating, and optional date override.
+// When overrideDate is provided, the workout is atomically moved to that date
+// (used by the "Move to today" late-completion prompt — no Late stigma stored).
 export async function completeWorkout(
   ownerUsername: string,
   id: string,
   completed: boolean,
   notes?: string,
-  rating?: 1 | 2 | 3 | 4 | 5
+  rating?: 1 | 2 | 3 | 4 | 5,
+  overrideDate?: Date,
 ): Promise<void> {
   try {
     const docRef = doc(getDbInstance(), 'users', ownerUsername, 'workouts', id);
 
-    // Get workout to check if completion is late
     const workoutSnap = await getDoc(docRef);
     if (!workoutSnap.exists()) {
       throw new Error('Workout not found');
@@ -372,23 +374,18 @@ export async function completeWorkout(
     if (completed) {
       const now = new Date();
       const workoutDate = workoutSnap.data().date.toDate();
-
-      // Set workout date to end of day for fair comparison
       workoutDate.setHours(23, 59, 59, 999);
-
-      // Check if completing after due date
-      const isLate = now > workoutDate;
-
-      console.log('Late completion check:', {
-        now: now.toISOString(),
-        workoutDate: workoutDate.toISOString(),
-        isLate,
-        workoutName: workoutSnap.data().name
-      });
 
       updateData.completedAt = serverTimestamp();
       updateData.completedBy = 'manual';
-      updateData.completedLate = isLate;
+
+      if (overrideDate) {
+        // User chose "Move to today" — update date atomically, no lateness recorded
+        updateData.date = Timestamp.fromDate(overrideDate);
+        updateData.completedLate = false;
+      } else {
+        updateData.completedLate = now > workoutDate;
+      }
 
       if (notes) {
         updateData.completionNotes = notes;


### PR DESCRIPTION
## Summary
- Remove all amber/orange **"Late"** UI badges from CalendarWorkoutCard, WorkoutDetailPanel, WorkoutCard, workouts page, and dashboard — late completions display identically to on-time completions (green "Done")
- Extend `completeWorkout()` with `overrideDate?: Date` for atomic date+completion writes
- Add **inline Dialog** on calendar: completing a past workout now shows "Keep on [date]" / "Move to today" instead of silently recording lateness
- `completedLate` Firestore field preserved untouched — AI prompts (chat, suggestions, reports) continue using it for LLM reasoning

## What changed

| Surface | Before | After |
|---------|--------|-------|
| CalendarWorkoutCard | Amber border + "Late" badge | Green "Done" |
| WorkoutDetailPanel | "Completed Late" in amber | "Completed" in green |
| WorkoutCard | Orange border + "Late" badge | Green "Done" |
| Workouts page | Amber "Late" badge + amber checkmark | Clean green checkmark |
| Dashboard page | Amber late styles | Green done styles |
| CoachDashboard | Orange check for late workouts | Green check always |
| Calendar completion (past) | Silent late flag stored | Dialog: Keep on [date] / Move to today |

## PostHog events
- `late_completion_prompt_choice` with `{ choice: 'keep' | 'move_to_today', workout_id }`

## Post-Deploy Monitoring & Validation
- **No additional operational monitoring required**: UI-only change + local Firestore write pattern. No new API routes, no schema changes, no migration needed.

---

Closes #106

[![Compound Engineering v2.47.0](https://img.shields.io/badge/Compound_Engineering-v2.47.0-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Sonnet 4.6 via [Claude Code](https://claude.com/claude-code)